### PR TITLE
spec: Remove scylla-server dependency

### DIFF
--- a/dist/redhat/scylla-tools.spec.in
+++ b/dist/redhat/scylla-tools.spec.in
@@ -11,7 +11,7 @@ URL:            http://www.scylladb.com/
 Source0:        %{name}-@@VERSION@@-@@RELEASE@@.tar
 BuildArch:      noarch
 BuildRequires:  ant java-devel python
-Requires:       java-headless python python-yaml scylla-server
+Requires:       java-headless python python-yaml
 
 %description
 


### PR DESCRIPTION
(To be merged after scylla "[PATCH] spec: Extract scylla.yaml and create metapackage" and the equivalent ubuntu patch)

Now that the scylla.yaml configuration file is in scylla-conf
we can remove the dependency on scylla-server.

Fixes #421

Signed-of-by: Benoît Canet <benoit@scylladb.com>