### PR TITLE
install.sh: install fakeroot

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -22,5 +22,5 @@
 if [ "$ID" = "ubuntu" ] || [ "$ID" = "debian" ]; then
     apt -y install openjdk-8-jdk-headless ant ant-optional python
 elif [ "$ID" = "fedora" ] || [ "$ID" = "centos" ]; then
-    yum install -y ant java-1.8.0-openjdk-devel python ant-junit
+    yum install -y ant java-1.8.0-openjdk-devel python ant-junit fakeroot
 fi


### PR DESCRIPTION
fakeroot is needed to build debian packages on fedora, and it is not
installed by default. It is probably installed by scylla, so in a system
where all packages are being built this will likely be fine, but trying
to build just the tools will lead to failure.

Signed-off-by: Glauber Costa <glauber@scylladb.com>