### PR TITLE
cassandra.in.sh: copy only config file to conf

### DIFF
--- a/dist/common/cassandra.in.sh
+++ b/dist/common/cassandra.in.sh
@@ -2,6 +2,13 @@
 SCYLLA_HOME=/var/lib/scylla
 SCYLLA_CONF=/etc/scylla
 
+function cp_conf_dir {
+    cp -a "$1"/*.yaml "$2"  2>/dev/null || true
+    cp -a "$1"/*.xml "$2"  2>/dev/null || true
+    cp -a "$1"/*.options "$2"  2>/dev/null || true
+    cp -a "$1"/*.properties "$2"  2>/dev/null || true
+}
+
 # Scylla adaption. Some one will still have to find us SCYLLA_HOME
 # or place us there.
 if [ -f "$SCYLLA_CONF/scylla.yaml" ]; then
@@ -11,10 +18,11 @@ if [ -f "$SCYLLA_CONF/scylla.yaml" ]; then
         # Create a temp config dir for just this execution
         TMPCONF=`mktemp -d`
         trap "rm -rf $TMPCONF" EXIT
-        cp -a "$SCYLLA_CONF"/* "$TMPCONF"
-        # extract config files under /etc/scylla/cassandra/ to $TMPCONF
-        mv $TMPCONF/cassandra/* $TMPCONF
-        rm -rf $TMPCONF/cassandra/
+        cp_conf_dir "$SCYLLA_CONF" "$TMPCONF"
+        if [ -d $SCYLLA_CONF/cassandra/ ]; then
+            # extract config files under /etc/scylla/cassandra/ to $TMPCONF
+            cp_conf_dir "$SCYLLA_CONF/cassandra" "$TMPCONF"
+        fi
         # Filter out scylla specific options that make
         # cassandra options parser go boom.
         # Also add attributes not present in scylla.yaml

--- a/tools/bin/cassandra.in.sh
+++ b/tools/bin/cassandra.in.sh
@@ -46,6 +46,14 @@ fi
 if [ "x$SCYLLA_CONF" = "x" ]; then
     SCYLLA_CONF="$SCYLLA_HOME/conf"
 fi
+
+function cp_conf_dir {
+    cp -a "$1"/*.yaml "$2"  2>/dev/null || true
+    cp -a "$1"/*.xml "$2"  2>/dev/null || true
+    cp -a "$1"/*.options "$2"  2>/dev/null || true
+    cp -a "$1"/*.properties "$2"  2>/dev/null || true
+}
+
 if [ -f "$SCYLLA_CONF/scylla.yaml" ]; then
     if [ -f "$SCYLLA_CONF/cassandra.yaml" ]; then
     CASSANDRA_CONF=$SCYLLA_CONF
@@ -53,8 +61,8 @@ if [ -f "$SCYLLA_CONF/scylla.yaml" ]; then
     # Create a temp config dir for just this execution
     TMPCONF=`mktemp -d`
     trap "rm -rf $TMPCONF" EXIT
-    cp -a "$CASSANDRA_CONF"/* "$TMPCONF"
-    cp -a "$SCYLLA_CONF"/* "$TMPCONF"
+    cp_conf_dir "$CASSANDRA_CONF" "$TMPCONF"
+    cp_conf_dir "$SCYLLA_CONF" "$TMPCONF"
     # Filter out scylla specific options that make
     # cassandra options parser go boom.
     # Also add attributes not present in scylla.yaml


### PR DESCRIPTION
This patch changes how configuration files are copied to the config
directory.

To prevent unneeded large file copy, only yaml files are copied.

Fixes #94