### PR TITLE
Fix cqlsh on debian installations

### DIFF
--- a/dist/debian/debian/scylla-tools.install
+++ b/dist/debian/debian/scylla-tools.install
@@ -12,4 +12,4 @@ tools/bin/sstablemetadata usr/bin
 tools/bin/sstablerepairedset usr/bin
 tools/bin/sstablesplit usr/bin
 dist/common/nodetool-completion etc/bash_completion.d/nodetool
-pylib/usr/* usr
+pylib/root/* .

--- a/dist/debian/rules.mustache
+++ b/dist/debian/rules.mustache
@@ -20,10 +20,9 @@ build:
 install:
 	dh_testdir
 	dh_testroot
-	mkdir -p $(CURDIR)pylib/usr
+	mkdir -p $(CURDIR)pylib/root
 	# Debian overrides site-packages to dist-packages; humor it or nothing works
-	cd $(CURDIR)/pylib && python setup.py install --no-compile --root $(CURDIR)/pylib/usr --install-lib /usr/lib/python2.7/dist-packages
-	cd $(CURDIR)
+	cd $(CURDIR)/pylib && python setup.py install --no-compile --root $(CURDIR)/pylib/root --install-lib /usr/lib/python2.7/dist-packages
 	dh_installdirs
 	dh_install
 

--- a/dist/debian/rules.mustache
+++ b/dist/debian/rules.mustache
@@ -21,7 +21,8 @@ install:
 	dh_testdir
 	dh_testroot
 	mkdir -p $(CURDIR)pylib/usr
-	cd $(CURDIR)/pylib && python setup.py install --no-compile --root $(CURDIR)/pylib/usr
+	# Debian overrides site-packages to dist-packages; humor it or nothing works
+	cd $(CURDIR)/pylib && python setup.py install --no-compile --root $(CURDIR)/pylib/usr --install-lib /usr/lib/python2.7/dist-packages
 	cd $(CURDIR)
 	dh_installdirs
 	dh_install


### PR DESCRIPTION
This series fixes two bugs related to cqlsh installation on debian systems. First, debian doesn't use the standard `site-packages` directory; instead it uses `dist-packages`. Debian python distutils is patched appropriately and installs to the correct directory, but if we build the debian package on Fedora (as we do) the patch is not there, and the files are installed to the wrong directory and not picked up by python.

Second, 87dab77c1e797 ("make sure cqlsh works from the .tar.gz installation") had a mistake in its scylla-tools.install file which caused files which were meant for /usr into /usr/usr. As might be expected, python didn't pick up the files from there either.

Fixes #112 
Fixes #113 

Ref scylladb/scylla#4738