### PR TITLE
None of the nodetool commands are working on master AMI

### DIFF
--- a/dist/common/cassandra.in.sh
+++ b/dist/common/cassandra.in.sh
@@ -7,6 +7,7 @@ function cp_conf_dir {
     cp -a "$1"/*.xml "$2"  2>/dev/null || true
     cp -a "$1"/*.options "$2"  2>/dev/null || true
     cp -a "$1"/*.properties "$2"  2>/dev/null || true
+    cp -a "$1"/cassandra-env.sh "$2"  2>/dev/null || true
 }
 
 # Scylla adaption. Some one will still have to find us SCYLLA_HOME

--- a/tools/bin/cassandra.in.sh
+++ b/tools/bin/cassandra.in.sh
@@ -52,6 +52,7 @@ function cp_conf_dir {
     cp -a "$1"/*.xml "$2"  2>/dev/null || true
     cp -a "$1"/*.options "$2"  2>/dev/null || true
     cp -a "$1"/*.properties "$2"  2>/dev/null || true
+    cp -a "$1"/cassandra-env.sh "$2"  2>/dev/null || true
 }
 
 if [ -f "$SCYLLA_CONF/scylla.yaml" ]; then


### PR DESCRIPTION
fixes #5067

Port for nodetool command was not filled in.

/etc/scylla/cassandra/cassandra-env.sh fills in this port, so
source files need to copy it to temporary directory