### PR TITLE
shell: fix incompatible function definition

### DIFF
--- a/dist/common/cassandra.in.sh
+++ b/dist/common/cassandra.in.sh
@@ -2,7 +2,7 @@
 SCYLLA_HOME=/var/lib/scylla
 SCYLLA_CONF=/etc/scylla
 
-function cp_conf_dir {
+function cp_conf_dir () {
     cp -a "$1"/*.yaml "$2"  2>/dev/null || true
     cp -a "$1"/*.xml "$2"  2>/dev/null || true
     cp -a "$1"/*.options "$2"  2>/dev/null || true

--- a/tools/bin/cassandra.in.sh
+++ b/tools/bin/cassandra.in.sh
@@ -47,7 +47,7 @@ if [ "x$SCYLLA_CONF" = "x" ]; then
     SCYLLA_CONF="$SCYLLA_HOME/conf"
 fi
 
-function cp_conf_dir {
+function cp_conf_dir () {
     cp -a "$1"/*.yaml "$2"  2>/dev/null || true
     cp -a "$1"/*.xml "$2"  2>/dev/null || true
     cp -a "$1"/*.options "$2"  2>/dev/null || true


### PR DESCRIPTION
nodetool doesn't work on deb distros.

scylla-test@amos-ubuntu16:~$ nodetool status
/usr/bin/nodetool: 5: /usr/share/scylla/cassandra/cassandra.in.sh: function: not found
/usr/bin/nodetool: 11: /usr/share/scylla/cassandra/cassandra.in.sh: Syntax error: "}" unexpected

bin/nodetool is interpreted by /bin/sh, it points to bash on CentOS, and points
to dash on deb distros. This patch fixed two incompatible function definition.

Fixes #116

Signed-off-by: Amos Kong <amos@scylladb.com>

/CC @amnonh @syuu1228 