### PR TITLE
shell: refix incompatible function definition

### DIFF
--- a/dist/common/cassandra.in.sh
+++ b/dist/common/cassandra.in.sh
@@ -2,7 +2,7 @@
 SCYLLA_HOME=/var/lib/scylla
 SCYLLA_CONF=/etc/scylla
 
-function cp_conf_dir () {
+cp_conf_dir () {
     cp -a "$1"/*.yaml "$2"  2>/dev/null || true
     cp -a "$1"/*.xml "$2"  2>/dev/null || true
     cp -a "$1"/*.options "$2"  2>/dev/null || true

--- a/tools/bin/cassandra.in.sh
+++ b/tools/bin/cassandra.in.sh
@@ -47,7 +47,7 @@ if [ "x$SCYLLA_CONF" = "x" ]; then
     SCYLLA_CONF="$SCYLLA_HOME/conf"
 fi
 
-function cp_conf_dir () {
+cp_conf_dir () {
     cp -a "$1"/*.yaml "$2"  2>/dev/null || true
     cp -a "$1"/*.xml "$2"  2>/dev/null || true
     cp -a "$1"/*.options "$2"  2>/dev/null || true


### PR DESCRIPTION
Commit 64ba725727e05898264bf334a39e4ea4b8d6bcdb didn't fix the problem.
Let's change it to a function definition in POSIX shell.

reference:
- https://www.jpsdomain.org/public/2008-JP_bash_vs_dash.pdf
- https://wiki.ubuntu.com/DashAsBinSh#function

/CC @amnonh @penberg 