### PR TITLE
Make cqlshlib compatible with Python 3

### DIFF
--- a/pylib/cqlshlib/formatting.py
+++ b/pylib/cqlshlib/formatting.py
@@ -485,7 +485,7 @@ def format_value_text(val, encoding, colormap, quote=False, **_):
     if quote:
         bval = "'%s'" % bval
 
-    return bval if colormap is NO_COLOR_MAP else color_text(bval, colormap, wcwidth.wcswidth(bval.decode(encoding)))
+    return bval if colormap is NO_COLOR_MAP else color_text(bval.decode(encoding), colormap, wcwidth.wcswidth(bval.decode(encoding)))
 
 
 # name alias

--- a/pylib/cqlshlib/util.py
+++ b/pylib/cqlshlib/util.py
@@ -15,14 +15,22 @@
 # limitations under the License.
 
 
+from __future__ import print_function
 import cProfile
 import codecs
 import pstats
 
-from itertools import izip
+try:
+    from itertools import izip
+except ImportError:
+    izip = zip
+    
 from datetime import timedelta, tzinfo
-from StringIO import StringIO
-
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+    
 try:
     from line_profiler import LineProfiler
     HAS_LINE_PROFILER = True
@@ -161,6 +169,6 @@ def profile_off(pr, file_name):
     ret = s.getvalue()
     if file_name:
         with open(file_name, 'w') as f:
-            print "Writing to %s\n" % (f.name, )
+            print("Writing to %s\n" % (f.name, ))
             f.write(ret)
     return ret


### PR DESCRIPTION
This fixes some issues in cqlshlib, which make it incompatible with 
Python 3.

We eventually need to make the whole cqlsh work with Python 3 similar to 
what upstream Apache Cassandra is doing:

https://issues.apache.org/jira/browse/CASSANDRA-10190

However, the main motivation for this change is to make sure we can port 
users of cqlshlib (such as scylla-dtest) to Python 3 now.

Tested on both Python 2 and Python 3.
