### PR TITLE
dist/common/cassandra.in.sh: add cassandra_storagedir

### DIFF
--- a/dist/common/cassandra.in.sh
+++ b/dist/common/cassandra.in.sh
@@ -2,6 +2,9 @@
 SCYLLA_HOME=/var/lib/scylla
 SCYLLA_CONF=/etc/scylla
 
+# the default location for commitlogs, sstables, and saved caches
+cassandra_storagedir="$SCYLLA_HOME/data"
+
 cp_conf_dir () {
     cp -a "$1"/*.yaml "$2"  2>/dev/null || true
     cp -a "$1"/*.xml "$2"  2>/dev/null || true


### PR DESCRIPTION
On our package, we specify empty parameter on "-Dcassandra.storagedir"  for
Java based programs, it because dist/common/cassandra.in.sh does not
initialized it.
Seems like tools/bin/cassandra.in.sh does initialize it, we can do same in
dist/common/cassandra.in.sh too.

(dist/common/cassandra.in.sh is for package, tools/bin/cassandra.in.sh is for
built from source code)