### PR TITLE
stress: Remove "COMPACT STORAGE" from default c-s schema

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/settings/SettingsSchema.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/SettingsSchema.java
@@ -150,7 +150,7 @@ public class SettingsSchema implements Serializable
         }
 
         //Compression
-        b.append(") WITH COMPACT STORAGE AND compression = {");
+        b.append(") WITH compression = {");
         if (compression != null)
             b.append("'sstable_compression' : '").append(compression).append("'");
 
@@ -191,7 +191,7 @@ public class SettingsSchema implements Serializable
         }
 
         //Compression
-        b.append(") WITH COMPACT STORAGE AND compression = {");
+        b.append(") WITH compression = {");
         if (compression != null)
             b.append("'sstable_compression' : '").append(compression).append("'");
 


### PR DESCRIPTION
COMPACT STORAGE is not used by default when creating a table in Scylla.
It's also not recommended anymore and cassandra supports an alter command to remove it but scylla don't support it yet.
The usage of compact storage have some limitations like adding and dropping columns.