### PR TITLE
maven: switch repository URL to https

### DIFF
--- a/build.properties.default
+++ b/build.properties.default
@@ -1,4 +1,4 @@
 # Maven2 Repository Locations (you can override these in "build.properties" to point to a local proxy, e.g. Nexus)
-artifact.remoteRepository.central:     http://repo1.maven.org/maven2
-artifact.remoteRepository.apache:      http://repo.maven.apache.org/maven2
+artifact.remoteRepository.central:     https://repo1.maven.org/maven2
+artifact.remoteRepository.apache:      https://repo.maven.apache.org/maven2
 

--- a/build.xml
+++ b/build.xml
@@ -86,7 +86,7 @@
     <property name="maven-ant-tasks.version" value="2.1.3" />
     <property name="maven-ant-tasks.local" value="${user.home}/.m2/repository/org/apache/maven/maven-ant-tasks"/>
     <property name="maven-ant-tasks.url"
-              value="http://repo2.maven.org/maven2/org/apache/maven/maven-ant-tasks" />
+              value="https://repo1.maven.org/maven2/org/apache/maven/maven-ant-tasks" />
     <!-- details of how and which Maven repository we publish to -->
     <property name="maven.version" value="3.0.3" />
     <condition property="maven-repository-url" value="https://repository.apache.org/service/local/staging/deploy/maven2">


### PR DESCRIPTION
It seems maven central repository no longer support http, we need to switch to https:
https://support.sonatype.com/hc/en-us/articles/360041287334

Fixes #137