### PR TITLE
cassandra-stress: Silence NoSuchElementException warnings when iterator is exhausted

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/Operation.java
+++ b/tools/stress/src/org/apache/cassandra/stress/Operation.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.stress;
 
 import java.io.IOException;
+import java.util.NoSuchElementException;
 
 import org.apache.cassandra.stress.report.Timer;
 import org.apache.cassandra.stress.settings.SettingsLog;
@@ -84,6 +85,10 @@ public abstract class Operation
             {
                 success = run.run();
                 break;
+            }
+            catch (NoSuchElementException e) {
+                // Pass thru iterator exhaustion exception
+                throw e;
             }
             catch (Exception e)
             {

--- a/tools/stress/src/org/apache/cassandra/stress/StressAction.java
+++ b/tools/stress/src/org/apache/cassandra/stress/StressAction.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.LockSupport;
+import java.util.NoSuchElementException;
 
 import org.apache.cassandra.stress.operations.OpDistribution;
 import org.apache.cassandra.stress.operations.OpDistributionFactory;
@@ -476,8 +477,10 @@ public class StressAction implements Runnable
                                 op.run(tclient);
                         }
                     }
-                    catch (Exception e)
-                    {
+                    catch (NoSuchElementException e) {
+                        // Silently reiterate when iterator is exhausted
+                    }
+                    catch (Exception e) {
                         if (output == null)
                             System.err.println(e.getMessage());
                         else

--- a/tools/stress/src/org/apache/cassandra/stress/operations/userdefined/SchemaInsert.java
+++ b/tools/stress/src/org/apache/cassandra/stress/operations/userdefined/SchemaInsert.java
@@ -69,30 +69,27 @@ public class SchemaInsert extends SchemaStatement
     private class JavaDriverRun extends Runner
     {
         final JavaDriverClient client;
-        List<BoundStatement> stmts;
 
         private JavaDriverRun(JavaDriverClient client)
         {
             this.client = client;
-            this.stmts = new ArrayList<>();
         }
 
         public boolean run() throws Exception
         {
+            List<BoundStatement> stmts = new ArrayList<>();
             partitionCount = partitions.size();
 
-            if (stmts.size() == 0) {
-                for (PartitionIterator iterator : partitions)
-                    while (iterator.hasNext())
-                        stmts.add(bindRow(iterator.next()));
-            }
+            for (PartitionIterator iterator : partitions)
+                while (iterator.hasNext())
+                    stmts.add(bindRow(iterator.next()));
 
             rowCount += stmts.size();
 
             // 65535 is max number of stmts per batch, so if we have more, we need to manually batch them
-            while (stmts.size() > 0)
+            for (int j = 0 ; j < stmts.size() ; j += 65535)
             {
-                List<BoundStatement> substmts = stmts.subList(0, Math.min(stmts.size(), 65535));
+                List<BoundStatement> substmts = stmts.subList(j, Math.min(j + stmts.size(), j + 65535));
                 Statement stmt;
                 if (stmts.size() == 1)
                 {
@@ -107,7 +104,6 @@ public class SchemaInsert extends SchemaStatement
                 }
 
                 client.getSession().execute(stmt);
-                stmts = stmts.subList(substmts.size(),stmts.size());
             }
             return true;
         }

--- a/tools/stress/src/org/apache/cassandra/stress/operations/userdefined/SchemaQuery.java
+++ b/tools/stress/src/org/apache/cassandra/stress/operations/userdefined/SchemaQuery.java
@@ -63,7 +63,6 @@ public class SchemaQuery extends SchemaStatement
     private class JavaDriverRun extends Runner
     {
         final JavaDriverClient client;
-        BoundStatement bs;
 
         private JavaDriverRun(JavaDriverClient client)
         {
@@ -72,10 +71,7 @@ public class SchemaQuery extends SchemaStatement
 
         public boolean run() throws Exception
         {
-            if (bs == null) {
-                bs = bindArgs();
-            }
-            ResultSet rs = client.getSession().execute(bs);
+            ResultSet rs = client.getSession().execute(bindArgs());
             rowCount = rs.all().size();
             partitionCount = Math.min(1, rowCount);
             return true;


### PR DESCRIPTION
Addressing having following errors when iterator exhausted:

java.util.NoSuchElementException
java.util.NoSuchElementException
java.util.NoSuchElementException
java.util.NoSuchElementException
java.util.NoSuchElementException
java.util.NoSuchElementException
java.io.IOException: Operation x10 on key(s) [49a26f35297303469236]: Error executing: (NoSuchElementException)
at org.apache.cassandra.stress.Operation.error(Operation.java:127)java.util.NoSuchElementException
at org.apache.cassandra.stress.Operation.timeWithRetry(Operation.java:105)com.datastax.driver.core.exceptions.TransportException: [/127.0.0.1:9042] Connection has been closed
java.util.NoSuchElementException
java.util.NoSuchElementException
java.util.NoSuchElementException
java.util.NoSuchElementException
java.util.NoSuchElementException