### PR TITLE
fix(StressProfile.java): fix c-s failing when profile table is extended with set<set<>> column

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/StressProfile.java
+++ b/tools/stress/src/org/apache/cassandra/stress/StressProfile.java
@@ -532,6 +532,8 @@ public class StressProfile implements Serializable
                         boolean firstCol = true;
                         boolean firstPred = true;
                         for (ColumnMetadata c : tableMetaData.getColumns()) {
+                            if (!isTypeSupported(c.getType()))
+                                continue;
 
                             if (keyColumns.contains(c)) {
                                 if (firstPred)
@@ -667,6 +669,22 @@ public class StressProfile implements Serializable
         return builder.apply(defValue);
     }
 
+    private static boolean isTypeSupported(DataType dataType) {
+        // Maps are not supported due to lack of a corresponding generator.
+        // Embedded collections are not supported for the same reason.
+        if (!dataType.isCollection())
+            return true;
+        List<com.datastax.driver.core.DataType> arguments = dataType.getTypeArguments();
+        if (arguments.size() >= 2)
+            return false;
+        for (com.datastax.driver.core.DataType argumentType : arguments) {
+            if (argumentType.isCollection()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     public PartitionGenerator newGenerator(StressSettings settings)
     {
         if (generatorFactory == null)
@@ -676,7 +694,7 @@ public class StressProfile implements Serializable
                 maybeCreateSchema(settings);
                 maybeLoadSchemaInfo(settings);
                 if (generatorFactory == null)
-                    generatorFactory = new GeneratorFactory();
+                    generatorFactory = new GeneratorFactory(settings);
             }
         }
 
@@ -689,23 +707,33 @@ public class StressProfile implements Serializable
         final List<ColumnInfo> clusteringColumns = new ArrayList<>();
         final List<ColumnInfo> valueColumns = new ArrayList<>();
 
-        private GeneratorFactory()
+        private GeneratorFactory(StressSettings settings)
         {
+            List<ColumnInfo> unsupportedColumns = new ArrayList<>();
+            List<ColumnInfo> unsupportedCriticalColumns = new ArrayList<>();
             Set<ColumnMetadata> keyColumns = com.google.common.collect.Sets.newHashSet(tableMetaData.getPrimaryKey());
 
             for (ColumnMetadata metadata : tableMetaData.getPartitionKey())
-                partitionKeys.add(new ColumnInfo(metadata.getName(), metadata.getType().getName().toString(),
-                                                 metadata.getType().isCollection() ? metadata.getType().getTypeArguments().get(0).getName().toString() : "",
-                                                 columnConfigs.get(metadata.getName())));
+                pushColumnInfo(metadata, partitionKeys, true, unsupportedColumns, unsupportedCriticalColumns);
             for (ColumnMetadata metadata : tableMetaData.getClusteringColumns())
-                clusteringColumns.add(new ColumnInfo(metadata.getName(), metadata.getType().getName().toString(),
-                                                     metadata.getType().isCollection() ? metadata.getType().getTypeArguments().get(0).getName().toString() : "",
-                                                     columnConfigs.get(metadata.getName())));
-            for (ColumnMetadata metadata : tableMetaData.getColumns())
+                pushColumnInfo(metadata, clusteringColumns, true, unsupportedColumns, unsupportedCriticalColumns);
+            for (ColumnMetadata metadata : tableMetaData.getColumns()) {
                 if (!keyColumns.contains(metadata))
-                    valueColumns.add(new ColumnInfo(metadata.getName(), metadata.getType().getName().toString(),
-                                                    metadata.getType().isCollection() ? metadata.getType().getTypeArguments().get(0).getName().toString() : "",
-                                                    columnConfigs.get(metadata.getName())));
+                    pushColumnInfo(metadata, valueColumns, !(settings.errors.skipUnsupportedColumns), unsupportedColumns, unsupportedCriticalColumns);
+            }
+            if (unsupportedColumns.size() > 0) {
+                for (ColumnInfo column : unsupportedColumns) {
+                    System.err.printf("WARNING: Table '%s' has column '%s' of unsupported type\n",
+                            tableName, column.name);
+                }
+            }
+            if (unsupportedCriticalColumns.size() > 0) {
+                for (ColumnInfo column : unsupportedCriticalColumns) {
+                    System.err.printf("ERROR: Table '%s' has column '%s' of unsupported type\n",
+                            tableName, column.name);
+                }
+                assert false: "Can't continue due to the errors";
+            }
         }
 
         PartitionGenerator newGenerator(StressSettings settings)
@@ -719,6 +747,24 @@ public class StressProfile implements Serializable
             for (ColumnInfo columnInfo : columnInfos)
                 result.add(columnInfo.getGenerator());
             return result;
+        }
+
+        boolean pushColumnInfo(ColumnMetadata metadata, List<ColumnInfo> targetList, boolean isCritical,
+                                   List<ColumnInfo> unsupportedColumns, List<ColumnInfo> unsupportedCriticalColumns)
+        {
+            ColumnInfo column = new ColumnInfo(metadata.getName(), metadata.getType().getName().toString(),
+                    metadata.getType().isCollection() ? metadata.getType().getTypeArguments().get(0).getName().toString() : "",
+                    columnConfigs.get(metadata.getName()));
+            if (!isTypeSupported(metadata.getType())) {
+                if (isCritical) {
+                    unsupportedCriticalColumns.add(column);
+                } else {
+                    unsupportedColumns.add(column);
+                }
+                return false;
+            }
+            targetList.add(column);
+            return true;
         }
     }
 

--- a/tools/stress/src/org/apache/cassandra/stress/settings/SettingsErrors.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/SettingsErrors.java
@@ -34,12 +34,14 @@ public class SettingsErrors implements Serializable
     public final boolean ignore;
     public final int tries;
     public final boolean skipReadValidation;
+    public final boolean skipUnsupportedColumns;
 
     public SettingsErrors(Options options)
     {
         ignore = options.ignore.setByUser();
         this.tries = Math.max(1, Integer.parseInt(options.retries.value()) + 1);
         skipReadValidation = options.skipReadValidation.setByUser();
+        skipUnsupportedColumns = options.skipUnsupportedColumns.setByUser();
     }
 
     // Option Declarations
@@ -49,10 +51,11 @@ public class SettingsErrors implements Serializable
         final OptionSimple retries = new OptionSimple("retries=", "[0-9]+", "9", "Number of tries to perform for each operation before failing", false);
         final OptionSimple ignore = new OptionSimple("ignore", "", null, "Do not fail on errors", false);
         final OptionSimple skipReadValidation = new OptionSimple("skip-read-validation", "", null, "Skip read validation and message output", false);
+        final OptionSimple skipUnsupportedColumns = new OptionSimple("skip-unsupported-columns", "", null, "Skip unsupported columns, such as maps and embedded collections, when generating data for a user profile.", false);
         @Override
         public List<? extends Option> options()
         {
-            return Arrays.asList(retries, ignore, skipReadValidation);
+            return Arrays.asList(retries, ignore, skipReadValidation, skipUnsupportedColumns);
         }
     }
 


### PR DESCRIPTION
Comes from https://github.com/scylladb/scylla-cluster-tests/pull/1858

Reason:
c-s reads metadata from database, and build column generator from it.
But this logic is build in a way so that it does not support generator recursion, which is necessary to support embedded collections.

Fix:
This fix is simple exclude this type of columns from being processed.

Steps to reproduce:
1. docker run -d --name scylladb scylladb/scylla
2. cassandra-stress user profile=cs_no_mv_basic_profile.yaml ops'(insert=1)' cl=ONE n=20 -pop seq=1..10000000 -port jmx=6868 -mode cql3 native -rate threads=2 -node 172.17.0.2
3. docker exec -ti scylladb cqlsh -e 'ALTER TABLE mview.users ADD ( asdasdasd set<frozen<set<int>>>);'
4. cassandra-stress user profile=cs_no_mv_basic_profile.yaml ops'(insert=1)' cl=ONE n=20 -pop seq=1..10000000 -port jmx=6868 -mode cql3 native -rate threads=2 -node 172.17.0.2

Result:
  Extra Schema Definitions: null
  Generator Configs:
    password: Size: Fixed:  key=80;
    last_name: Size: Uniform:  min=1,max=32;
    id: Size: Uniform:  min=1,max=10;
    first_name: Size: Fixed:  key=16;
    email: Size: Uniform:  min=16,max=50;
    username: Size: Uniform:  min=10,max=30;
  Query Definitions:
    read1: CQL:select * from mview.users where id = ? LIMIT 10;Fields:samerow;
  Token Range Queries:
  Insert Settings:
    partitions: fixed(1)
    batchtype: UNLOGGED
Connected to cluster: , max pending requests per connection 128, max connections per host 8
Datacenter: datacenter1; Host: /172.17.0.2:9042; Rack: rack1
Created schema. Sleeping 1s for propagation.
java.lang.NullPointerException
	at org.apache.cassandra.stress.StressProfile$ColumnInfo.getGenerator(StressProfile.java:760)
	at org.apache.cassandra.stress.StressProfile$ColumnInfo.getGenerator(StressProfile.java:800)
	at org.apache.cassandra.stress.StressProfile$ColumnInfo.getGenerator(StressProfile.java:800)
	at org.apache.cassandra.stress.StressProfile$ColumnInfo.getGenerator(StressProfile.java:755)
	at org.apache.cassandra.stress.StressProfile$GeneratorFactory.get(StressProfile.java:733)
	at org.apache.cassandra.stress.StressProfile$GeneratorFactory.newGenerator(StressProfile.java:726)
	at org.apache.cassandra.stress.StressProfile.newGenerator(StressProfile.java:696)
	at org.apache.cassandra.stress.StressProfile.printSettings(StressProfile.java:126)
	at org.apache.cassandra.stress.settings.StressSettings.lambda$printSettings$1(StressSettings.java:311)
	at java.util.LinkedHashMap.forEach(LinkedHashMap.java:684)
	at org.apache.cassandra.stress.settings.StressSettings.printSettings(StressSettings.java:311)
	at org.apache.cassandra.stress.Stress.run(Stress.java:95)
	at org.apache.cassandra.stress.Stress.main(Stress.java:62)



[cs_no_mv_basic_profile.zip](https://github.com/scylladb/scylla-tools-java/files/4249752/cs_no_mv_basic_profile.zip)


