### PR TITLE
cql_parsing: remove old quoted string rules

### DIFF
--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -143,8 +143,6 @@ JUNK ::= /([ \t\r\f\v]+|(--|[/][/])[^\n\r]*([\n\r]|$)|[/][*].*?[*][/])/ ;
 
 <stringLiteral> ::= <quotedStringLiteral>
                   | <pgStringLiteral> ;
-<quotedStringLiteral> ::= /'([^']|')*'/ ;
-<pgStringLiteral> ::= /(\$\$).*(\$\$)/ ;
 <quotedStringLiteral> ::= /'([^']|'')*'/ ;
 <pgStringLiteral> ::= /\$\$(?:(?!\$\$).)*\$\$/;
 <quotedName> ::=    /"([^"]|"")*"/ ;


### PR DESCRIPTION
This commit fixes an aggregated mistake in merges
from upstream. The string parsing rules for pg style
string have been mistakenly were added instead of being
replaced. Since the lexer works in a method of first mach
wins, the old parsing rules which were buggy persisted.
This caused to a mistake in parsing pg style strings that
contained single quotation mark.
This commit simply removes them so the new correct rules
will be used to parse the string.

Fixes #150