### PR TITLE
Remove unused CDC logic that prints warnings

### DIFF
--- a/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
+++ b/src/java/org/apache/cassandra/config/DatabaseDescriptor.java
@@ -487,33 +487,6 @@ public class DatabaseDescriptor
             }
         }
 
-        if (conf.cdc_total_space_in_mb == 0)
-        {
-            int preferredSize = 4096;
-            int minSize = 0;
-            try
-            {
-                // use 1/8th of available space.  See discussion on #10013 and #10199 on the CL, taking half that for CDC
-                minSize = Ints.saturatedCast((guessFileStore(conf.cdc_raw_directory).getTotalSpace() / 1048576) / 8);
-            }
-            catch (IOException e)
-            {
-                logger.debug("Error checking disk space", e);
-                throw new ConfigurationException(String.format("Unable to check disk space available to %s. Perhaps the Cassandra user does not have the necessary permissions",
-                                                               conf.cdc_raw_directory), e);
-            }
-            if (minSize < preferredSize)
-            {
-                logger.warn("Small cdc volume detected at {}; setting cdc_total_space_in_mb to {}.  You can override this in cassandra.yaml",
-                            conf.cdc_raw_directory, minSize);
-                conf.cdc_total_space_in_mb = minSize;
-            }
-            else
-            {
-                conf.cdc_total_space_in_mb = preferredSize;
-            }
-        }
-
         if (conf.cdc_enabled)
         {
             logger.info("cdc_enabled is true. Starting casssandra node with Change-Data-Capture enabled.");


### PR DESCRIPTION
Cassandra and Scylla have totally different CDC implementations. Logic
removed by this patch is relevant only to Cassandra CDC which is never present
when working with Scylla. The code prints warnings that are confusing for
the users so it's better to remove it especially that the code is effectively
useless.

Signed-off-by: Piotr Jastrzebski <piotr@scylladb.com>