### PR TITLE
Remove the confusing permission denied emitted at the start of nodetools output.

### DIFF
--- a/dist/redhat/scylla-tools.spec.mustache
+++ b/dist/redhat/scylla-tools.spec.mustache
@@ -66,6 +66,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_bindir}/sstablemetadata
 %{_bindir}/sstablerepairedset
 /opt/scylladb/share/cassandra/pylib/*
+%dir /opt/scylladb/share/cassandra/logs
 
 %files core
 %{_sysconfdir}/scylla/cassandra/cassandra-env.sh

--- a/install.sh
+++ b/install.sh
@@ -129,6 +129,7 @@ fi
 
 # scylla-tools
 install -d -m755 "$rprefix"/share/cassandra/pylib
+install -d -m766 "$rprefix"/share/cassandra/logs
 install -d -m755 "$retc"/bash_completion.d
 install -m644 dist/common/nodetool-completion "$retc"/bash_completion.d
 cp -r pylib/cqlshlib "$rprefix"/share/cassandra/pylib


### PR DESCRIPTION
This commit handles the confusing permission denied when running nodetool  (and alse other tools) with a user that doesn't have write permissions to /opr/scylladb/share/cassandra
