### PR TITLE
reloc-pkg: move all files under project name directory

### DIFF
--- a/dist/redhat/scylla-tools.spec
+++ b/dist/redhat/scylla-tools.spec
@@ -34,7 +34,7 @@ Requires:       /usr/lib64/python2.7/site-packages/_yaml.so
 Core files for scylla tools.
 
 %prep
-%setup -c
+%setup -n scylla-tools-package
 
 
 %build

--- a/reloc/build_deb.sh
+++ b/reloc/build_deb.sh
@@ -25,7 +25,7 @@ done
 if [[ ! $OPTS =~ --reloc-pkg ]]; then
     OPTS="$OPTS --reloc-pkg $RELOC_PKG"
 fi
-mkdir -p build/debian/scylla-package
-tar -C build/debian/scylla-package -xpf $RELOC_PKG
-cd build/debian/scylla-package
+mkdir -p build/debian/
+tar -C build/debian/ -xpf $RELOC_PKG
+cd build/debian/scylla-tools-package
 exec bash -x -e ./dist/debian/build_deb.sh $OPTS

--- a/reloc/build_rpm.sh
+++ b/reloc/build_rpm.sh
@@ -24,7 +24,7 @@ done
 if [[ ! $OPTS =~ --reloc-pkg ]]; then
     OPTS="$OPTS --reloc-pkg $RELOC_PKG"
 fi
-mkdir -p build/redhat/scylla-package
-tar -C build/redhat/scylla-package -xpf $RELOC_PKG SCYLLA-RELEASE-FILE SCYLLA-RELOCATABLE-FILE SCYLLA-VERSION-FILE SCYLLA-PRODUCT-FILE dist/redhat
-cd build/redhat/scylla-package
+mkdir -p build/redhat/
+tar -C build/redhat/ -xpf $RELOC_PKG scylla-tools-package/SCYLLA-RELEASE-FILE scylla-tools-package/SCYLLA-RELOCATABLE-FILE scylla-tools-package/SCYLLA-VERSION-FILE scylla-tools-package/SCYLLA-PRODUCT-FILE scylla-tools-package/dist/redhat
+cd build/redhat/scylla-tools-package
 exec ./dist/redhat/build_rpm.sh $OPTS

--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -27,6 +27,14 @@ import os
 import tarfile
 import pathlib
 
+RELOC_PREFIX='scylla-tools-package'
+def reloc_add(self, name, arcname=None, recursive=True, *, filter=None):
+    if arcname:
+        return self.add(name, arcname="{}/{}".format(RELOC_PREFIX, arcname))
+    else:
+        return self.add(name, arcname="{}/{}".format(RELOC_PREFIX, name))
+
+tarfile.TarFile.reloc_add = reloc_add
 
 ap = argparse.ArgumentParser(description='Create a relocatable scylla package.')
 ap.add_argument('--version', required=True,
@@ -41,23 +49,23 @@ output = args.dest
 
 ar = tarfile.open(output, mode='w|gz')
 pathlib.Path('build/SCYLLA-RELOCATABLE-FILE').touch()
-ar.add('build/SCYLLA-RELOCATABLE-FILE', arcname='SCYLLA-RELOCATABLE-FILE')
-ar.add('build/SCYLLA-RELEASE-FILE', arcname='SCYLLA-RELEASE-FILE')
-ar.add('build/SCYLLA-VERSION-FILE', arcname='SCYLLA-VERSION-FILE')
-ar.add('build/SCYLLA-PRODUCT-FILE', arcname='SCYLLA-PRODUCT-FILE')
-ar.add('dist')
-ar.add('conf')
-ar.add('bin')
-ar.add('tools')
-ar.add('lib')
-ar.add('doc')
-ar.add('pylib')
-ar.add('install.sh')
-ar.add('build/apache-cassandra-{}.jar'.format(version), arcname='lib/apache-cassandra-{}.jar'.format(version))
-ar.add('build/apache-cassandra-thrift-{}.jar'.format(version), arcname='lib/apache-cassandra-thrift-{}.jar'.format(version))
-ar.add('build/scylla-tools-{}.jar'.format(version), arcname='lib/scylla-tools-{}.jar'.format(version))
-ar.add('build/tools/lib/stress.jar', arcname='lib/stress.jar')
-ar.add('README.asc')
-ar.add('CHANGES.txt')
-ar.add('NEWS.txt')
-ar.add('CASSANDRA-14092.txt')
+ar.reloc_add('build/SCYLLA-RELOCATABLE-FILE', arcname='SCYLLA-RELOCATABLE-FILE')
+ar.reloc_add('build/SCYLLA-RELEASE-FILE', arcname='SCYLLA-RELEASE-FILE')
+ar.reloc_add('build/SCYLLA-VERSION-FILE', arcname='SCYLLA-VERSION-FILE')
+ar.reloc_add('build/SCYLLA-PRODUCT-FILE', arcname='SCYLLA-PRODUCT-FILE')
+ar.reloc_add('dist')
+ar.reloc_add('conf')
+ar.reloc_add('bin')
+ar.reloc_add('tools')
+ar.reloc_add('lib')
+ar.reloc_add('doc')
+ar.reloc_add('pylib')
+ar.reloc_add('install.sh')
+ar.reloc_add('build/apache-cassandra-{}.jar'.format(version), arcname='lib/apache-cassandra-{}.jar'.format(version))
+ar.reloc_add('build/apache-cassandra-thrift-{}.jar'.format(version), arcname='lib/apache-cassandra-thrift-{}.jar'.format(version))
+ar.reloc_add('build/scylla-tools-{}.jar'.format(version), arcname='lib/scylla-tools-{}.jar'.format(version))
+ar.reloc_add('build/tools/lib/stress.jar', arcname='lib/stress.jar')
+ar.reloc_add('README.asc')
+ar.reloc_add('CHANGES.txt')
+ar.reloc_add('NEWS.txt')
+ar.reloc_add('CASSANDRA-14092.txt')


### PR DESCRIPTION
To make unified relocatable package easily, we may want to merge tarballs to single tarball like this:
zcat .tar.gz | gzip -c > scylla-unified.tar.xz
But it's not possible with current relocatable package format, since there are multiple files conflicts, install.sh, SCYLLA--FILE, dist/, README.md, etc..

To support this, we need to archive everything in the directory when building relocatable package.

See: scylladb/scylla#6315