### PR TITLE
dist/redhat: drop dependency on pystache

### DIFF
--- a/dist/redhat/build_rpm.sh
+++ b/dist/redhat/build_rpm.sh
@@ -59,13 +59,6 @@ fi
 if [ ! -f /usr/bin/yum-builddep ]; then
     pkg_install yum-utils
 fi
-if [ ! -f /usr/bin/pystache ]; then
-    if is_redhat_variant; then
-        sudo yum install -y python2-pystache || sudo yum install -y pystache
-    elif is_debian_variant; then
-        sudo apt-get install -y python-pystache
-    fi
-fi
 
 SCYLLA_VERSION=$(cat SCYLLA-VERSION-FILE)
 SCYLLA_RELEASE=$(cat SCYLLA-RELEASE-FILE)
@@ -75,7 +68,13 @@ RPMBUILD=$(readlink -f ../)
 mkdir -p $RPMBUILD/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 
 ln -fv $RELOC_PKG $RPMBUILD/SOURCES/
-pystache dist/redhat/scylla-tools.spec.mustache "{ \"version\": \"$SCYLLA_VERSION\", \"release\": \"$SCYLLA_RELEASE\", \"product\": \"$PRODUCT\", \"$PRODUCT\": true }" > $RPMBUILD/SPECS/scylla-tools.spec
 
+parameters=(
+    -D"version $SCYLLA_VERSION"
+    -D"release $SCYLLA_RELEASE"
+    -D"product $PRODUCT"
+)
+
+cp dist/redhat/scylla-tools.spec $RPMBUILD/SPECS
 # this rpm can be install on both fedora / centos7, so drop distribution name from the file name
-rpmbuild -ba --define '_binary_payload w2.xzdio' --define "_topdir $RPMBUILD" --undefine "dist" $RPM_JOBS_OPTS $RPMBUILD/SPECS/scylla-tools.spec
+rpmbuild -ba "${parameters[@]}" --define '_binary_payload w2.xzdio' --define "_topdir $RPMBUILD" --undefine "dist" $RPM_JOBS_OPTS $RPMBUILD/SPECS/scylla-tools.spec

--- a/dist/redhat/scylla-tools.spec
+++ b/dist/redhat/scylla-tools.spec
@@ -1,6 +1,6 @@
-Name:           {{product}}-tools
-Version:        {{version}}
-Release:        {{release}}%{?dist}
+Name:           %{product}-tools
+Version:        %{version}
+Release:        %{release}%{?dist}
 Summary:        Scylla Tools
 Group:          Applications/Databases
 
@@ -8,7 +8,7 @@ License:        Apache
 URL:            http://www.scylladb.com/
 Source0:        scylla-tools-package.tar.gz
 BuildArch:      noarch
-Requires:       {{product}}-conf {{product}}-tools-core
+Requires:       %{product}-conf %{product}-tools-core
 Conflicts:      cassandra
 
 %description
@@ -19,8 +19,8 @@ URL:            http://www.scylladb.com/
 BuildArch:      noarch
 Requires:       java-headless
 Summary:        Core files for Scylla tools
-Version:        {{version}}
-Release:        {{release}}%{?dist}
+Version:        %{version}
+Release:        %{release}%{?dist}
 Requires:       java-1.8.0-openjdk-headless python2
 # Since RHEL7 and RHEL8 has different pacakge name for pyyaml,
 # we need to use a file path to the resolve package name on


### PR DESCRIPTION
Same as https://github.com/scylladb/scylla/pull/6313, drop dependency on
pystache since it nolong present in Fedora 32.