### PR TITLE
Configuration: stop adding gc logging option to JVM by default

### DIFF
--- a/conf/cassandra-env.sh
+++ b/conf/cassandra-env.sh
@@ -86,26 +86,6 @@ calculate_heap_sizes()
     fi
 }
 
-#GC log path has to be defined here because it needs to access CASSANDRA_HOME
-if [ $JAVA_VERSION -ge 11 ] ; then
-    # See description of https://bugs.openjdk.java.net/browse/JDK-8046148 for details about the syntax
-    # The following is the equivalent to -XX:+PrintGCDetails -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=10M
-    echo "$JVM_OPTS" | grep -q "^-[X]log:gc"
-    if [ "$?" = "1" ] ; then # [X] to prevent ccm from replacing this line
-        # only add -Xlog:gc if it's not mentioned in jvm-server.options file
-        mkdir -p ${CASSANDRA_HOME}/logs
-        JVM_OPTS="$JVM_OPTS -Xlog:gc=info,heap*=trace,age*=debug,safepoint=info,promotion*=trace:file=${CASSANDRA_HOME}/logs/gc.log:time,uptime,pid,tid,level:filecount=10,filesize=10485760"
-    fi
-else
-    # Java 8
-    echo "$JVM_OPTS" | grep -q "^-[X]loggc"
-    if [ "$?" = "1" ] ; then # [X] to prevent ccm from replacing this line
-        # only add -Xlog:gc if it's not mentioned in jvm-server.options file
-        mkdir -p ${CASSANDRA_HOME}/logs
-        JVM_OPTS="$JVM_OPTS -Xloggc:${CASSANDRA_HOME}/logs/gc.log"
-    fi
-fi
-
 # Check what parameters were defined on jvm-server.options file to avoid conflicts
 echo $JVM_OPTS | grep -q Xmn
 DEFINED_XMN=$?


### PR DESCRIPTION
After considering fixing the "Permission Denied" print that is
triggered with every call to one of the java tools. It was
decided it is best to loose of not logging the JVM GC by default
at all.
The log has little to none value to us since we are not running
the actual cassandra server where it might have been of value
if it crashes.
If a developer/user still needs those logs he can add it as a
parameter to the JVM_OPTS environment variable.
For the discussion and previous proposed solution see:
https://github.com/scylladb/scylla-tools-java/pull/153

Fixes #147 