### PR TITLE
reloc-pkg: move all files under project name directory

### DIFF
--- a/dist/debian/build_deb.sh
+++ b/dist/debian/build_deb.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-PRODUCT=$(cat SCYLLA-PRODUCT-FILE)
+PRODUCT=$(cat scylla-tools/SCYLLA-PRODUCT-FILE)
 
 . /etc/os-release
 print_usage() {
@@ -39,7 +39,7 @@ pkg_install() {
     fi
 }
 
-if [ ! -e SCYLLA-RELOCATABLE-FILE ]; then
+if [ ! -e scylla-tools/SCYLLA-RELOCATABLE-FILE ]; then
     echo "do not directly execute build_rpm.sh, use reloc/build_rpm.sh instead."
     exit 1
 fi
@@ -93,8 +93,10 @@ if [ -z "$TARGET" ]; then
 fi
 RELOC_PKG_FULLPATH=$(readlink -f $RELOC_PKG)
 RELOC_PKG_BASENAME=$(basename $RELOC_PKG)
-SCYLLA_VERSION=$(cat SCYLLA-VERSION-FILE)
-SCYLLA_RELEASE=$(cat SCYLLA-RELEASE-FILE)
+SCYLLA_VERSION=$(cat scylla-tools/SCYLLA-VERSION-FILE)
+SCYLLA_RELEASE=$(cat scylla-tools/SCYLLA-RELEASE-FILE)
 
 ln -fv $RELOC_PKG_FULLPATH ../$PRODUCT-tools_$SCYLLA_VERSION-$SCYLLA_RELEASE.orig.tar.gz
+
+cp -a scylla-tools/debian debian
 debuild -rfakeroot -us -uc

--- a/dist/debian/debian/rules
+++ b/dist/debian/debian/rules
@@ -10,7 +10,7 @@ override_dh_auto_clean:
 
 override_dh_auto_install:
 	dh_auto_install
-	./install.sh --root "$(CURDIR)/debian/tmp"
+	cd scylla-tools; ./install.sh --root "$(CURDIR)/debian/tmp"
 
 override_dh_makeshlibs:
 

--- a/dist/redhat/scylla-tools.spec
+++ b/dist/redhat/scylla-tools.spec
@@ -34,7 +34,7 @@ Requires:       /usr/lib64/python2.7/site-packages/_yaml.so
 Core files for scylla tools.
 
 %prep
-%setup -c
+%setup -n scylla-tools
 
 
 %build

--- a/reloc/build_deb.sh
+++ b/reloc/build_deb.sh
@@ -28,4 +28,4 @@ fi
 mkdir -p build/debian/scylla-package
 tar -C build/debian/scylla-package -xpf $RELOC_PKG
 cd build/debian/scylla-package
-exec bash -x -e ./dist/debian/build_deb.sh $OPTS
+exec bash -x -e ./scylla-tools/dist/debian/build_deb.sh $OPTS

--- a/reloc/build_rpm.sh
+++ b/reloc/build_rpm.sh
@@ -24,7 +24,7 @@ done
 if [[ ! $OPTS =~ --reloc-pkg ]]; then
     OPTS="$OPTS --reloc-pkg $RELOC_PKG"
 fi
-mkdir -p build/redhat/scylla-package
-tar -C build/redhat/scylla-package -xpf $RELOC_PKG SCYLLA-RELEASE-FILE SCYLLA-RELOCATABLE-FILE SCYLLA-VERSION-FILE SCYLLA-PRODUCT-FILE dist/redhat
-cd build/redhat/scylla-package
+mkdir -p build/redhat/
+tar -C build/redhat/ -xpf $RELOC_PKG scylla-tools/SCYLLA-RELEASE-FILE scylla-tools/SCYLLA-RELOCATABLE-FILE scylla-tools/SCYLLA-VERSION-FILE scylla-tools/SCYLLA-PRODUCT-FILE scylla-tools/dist/redhat
+cd build/redhat/scylla-tools
 exec ./dist/redhat/build_rpm.sh $OPTS

--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -27,6 +27,14 @@ import os
 import tarfile
 import pathlib
 
+RELOC_PREFIX='scylla-tools'
+def reloc_add(self, name, arcname=None, recursive=True, *, filter=None):
+    if arcname:
+        return self.add(name, arcname="{}/{}".format(RELOC_PREFIX, arcname))
+    else:
+        return self.add(name, arcname="{}/{}".format(RELOC_PREFIX, name))
+
+tarfile.TarFile.reloc_add = reloc_add
 
 ap = argparse.ArgumentParser(description='Create a relocatable scylla package.')
 ap.add_argument('--version', required=True,
@@ -40,25 +48,30 @@ version = args.version
 output = args.dest
 
 ar = tarfile.open(output, mode='w|gz')
+# relocatable package format version = 2
+with open('build/.relocatable_package_version', 'w') as f:
+    f.write('2\n')
+ar.add('build/.relocatable_package_version', arcname='.relocatable_package_version')
+
 pathlib.Path('build/SCYLLA-RELOCATABLE-FILE').touch()
-ar.add('build/SCYLLA-RELOCATABLE-FILE', arcname='SCYLLA-RELOCATABLE-FILE')
-ar.add('build/SCYLLA-RELEASE-FILE', arcname='SCYLLA-RELEASE-FILE')
-ar.add('build/SCYLLA-VERSION-FILE', arcname='SCYLLA-VERSION-FILE')
-ar.add('build/SCYLLA-PRODUCT-FILE', arcname='SCYLLA-PRODUCT-FILE')
-ar.add('dist')
-ar.add('conf')
-ar.add('bin')
-ar.add('tools')
-ar.add('lib')
-ar.add('doc')
-ar.add('pylib')
-ar.add('install.sh')
-ar.add('build/apache-cassandra-{}.jar'.format(version), arcname='lib/apache-cassandra-{}.jar'.format(version))
-ar.add('build/apache-cassandra-thrift-{}.jar'.format(version), arcname='lib/apache-cassandra-thrift-{}.jar'.format(version))
-ar.add('build/scylla-tools-{}.jar'.format(version), arcname='lib/scylla-tools-{}.jar'.format(version))
-ar.add('build/tools/lib/stress.jar', arcname='lib/stress.jar')
-ar.add('README.asc')
-ar.add('CHANGES.txt')
-ar.add('NEWS.txt')
-ar.add('CASSANDRA-14092.txt')
-ar.add('build/debian/debian', arcname='debian')
+ar.reloc_add('build/SCYLLA-RELOCATABLE-FILE', arcname='SCYLLA-RELOCATABLE-FILE')
+ar.reloc_add('build/SCYLLA-RELEASE-FILE', arcname='SCYLLA-RELEASE-FILE')
+ar.reloc_add('build/SCYLLA-VERSION-FILE', arcname='SCYLLA-VERSION-FILE')
+ar.reloc_add('build/SCYLLA-PRODUCT-FILE', arcname='SCYLLA-PRODUCT-FILE')
+ar.reloc_add('dist')
+ar.reloc_add('conf')
+ar.reloc_add('bin')
+ar.reloc_add('tools')
+ar.reloc_add('lib')
+ar.reloc_add('doc')
+ar.reloc_add('pylib')
+ar.reloc_add('install.sh')
+ar.reloc_add('build/apache-cassandra-{}.jar'.format(version), arcname='lib/apache-cassandra-{}.jar'.format(version))
+ar.reloc_add('build/apache-cassandra-thrift-{}.jar'.format(version), arcname='lib/apache-cassandra-thrift-{}.jar'.format(version))
+ar.reloc_add('build/scylla-tools-{}.jar'.format(version), arcname='lib/scylla-tools-{}.jar'.format(version))
+ar.reloc_add('build/tools/lib/stress.jar', arcname='lib/stress.jar')
+ar.reloc_add('README.asc')
+ar.reloc_add('CHANGES.txt')
+ar.reloc_add('NEWS.txt')
+ar.reloc_add('CASSANDRA-14092.txt')
+ar.reloc_add('build/debian/debian', arcname='debian')


### PR DESCRIPTION
*this is reopened version of https://github.com/scylladb/scylla-tools-java/pull/155, since it dequeued*

To make unified relocatable package easily, we may want to merge tarballs to single tarball like this:
zcat .tar.gz | gzip -c > scylla-unified.tar.xz
But it's not possible with current relocatable package format, since there are multiple files conflicts, install.sh, SCYLLA--FILE, dist/, README.md, etc..

To support this, we need to archive everything in the directory when building relocatable package.

See: scylladb/scylla#6315