### PR TITLE
dist: debian: fix detection of debuild

### DIFF
--- a/dist/debian/build_deb.sh
+++ b/dist/debian/build_deb.sh
@@ -63,7 +63,7 @@ fi
 if [ ! -f /usr/bin/python ]; then
     pkg_install python
 fi
-if [ ! -f /usr/sbin/debuild ]; then
+if [ ! -f /usr/bin/debuild ]; then
     pkg_install devscripts
 fi
 if [ ! -f /usr/bin/dh_testdir ]; then


### PR DESCRIPTION
We detect if debuild is already installed, in order to avoid
re-installing it, which can fail due to flakey mirrors. However,
we use the wrong path to detect if it is installed, so we do in fact
fail on flakey Fedora mirrors.

Fix by using the correct path.