### PR TITLE
NodeProbe: get all histogram values in a single call

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -89,3 +89,6 @@ http://hdrhistogram.org
 
 JCTools
 http://jctools.github.io/JCTools/
+
+BufferSamples
+https://github.com/scylladb/scylla-jmx


### PR DESCRIPTION
Table histagrams uses sampling to calculate the histogram.
There could be a potential problem when querying the JMX multiple times,
the values can potentiallay change so drastically that the histogram
values will not be monotonic.

This patch changes NodeProbe implementation, instead of querying each of
the quantile values from the JMX seperately, it will do a single request
to get the values and then will calculate the histogram itself using the
same aggregation class: BufferSamples as the jmx does.

Fixes scylladb/scylla#6792

Signed-off-by: Amnon Heiman <amnon@scylladb.com>