### PR TITLE
dist: redhat: reduce log spam from unpacking sources when building rpm

### DIFF
--- a/dist/redhat/scylla-tools.spec
+++ b/dist/redhat/scylla-tools.spec
@@ -34,7 +34,7 @@ Requires:       /usr/lib64/python2.7/site-packages/_yaml.so
 Core files for scylla tools.
 
 %prep
-%setup -n scylla-tools
+%setup -q -n scylla-tools
 
 
 %build


### PR DESCRIPTION
rpmbuild defaults to logging the name of every file it unpacks from
the archive. This is quite a lot for Java applications.

Make it quiet with the %setup -q flag.