### PR TITLE
fix(tools/stress/*): Add serial consistency options

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/StressYaml.java
+++ b/tools/stress/src/org/apache/cassandra/stress/StressYaml.java
@@ -42,9 +42,16 @@ public class StressYaml
     {
         public String cql;
         public String fields;
+        public String consistencyLevel;
+        public String serialConsistencyLevel;
         public String getConfigAsString()
         {
-            return String.format("CQL:%s;Fields:%s;", cql, fields);
+            String output = String.format("CQL:%s;Fields:%s;", cql, fields);
+            if (consistencyLevel != null)
+                output += String.format("consistencyLevel:%s;", consistencyLevel);
+            if (serialConsistencyLevel != null)
+                output += String.format("serialConsistencyLevel:%s;", serialConsistencyLevel);
+            return output;
         }
     }
 

--- a/tools/stress/src/org/apache/cassandra/stress/operations/predefined/CqlOperation.java
+++ b/tools/stress/src/org/apache/cassandra/stress/operations/predefined/CqlOperation.java
@@ -298,7 +298,7 @@ public abstract class CqlOperation<V> extends PredefinedOperation
         public <V> V execute(String query, ByteBuffer key, List<Object> queryParams, ResultHandler<V> handler)
         {
             String formattedQuery = formatCqlQuery(query, queryParams);
-            return handler.javaDriverHandler().apply(client.execute(formattedQuery, ThriftConversion.fromThrift(settings.command.consistencyLevel)));
+            return handler.javaDriverHandler().apply(client.execute(formattedQuery, settings.command.consistencyLevel, settings.command.serialConsistencyLevel));
         }
 
         @Override
@@ -308,7 +308,8 @@ public abstract class CqlOperation<V> extends PredefinedOperation
                     client.executePrepared(
                             (PreparedStatement) preparedStatementId,
                             queryParams,
-                            ThriftConversion.fromThrift(settings.command.consistencyLevel)));
+                            settings.command.consistencyLevel,
+                            settings.command.serialConsistencyLevel));
         }
 
         @Override
@@ -330,7 +331,7 @@ public abstract class CqlOperation<V> extends PredefinedOperation
         public <V> V execute(String query, ByteBuffer key, List<Object> queryParams, ResultHandler<V> handler)
         {
             String formattedQuery = formatCqlQuery(query, queryParams);
-            return handler.thriftHandler().apply(client.execute(formattedQuery, ThriftConversion.fromThrift(settings.command.consistencyLevel)));
+            return handler.thriftHandler().apply(client.execute(formattedQuery, settings.command.consistencyLevel));
         }
 
         @Override
@@ -340,7 +341,7 @@ public abstract class CqlOperation<V> extends PredefinedOperation
                     client.executePrepared(
                             (byte[]) preparedStatementId,
                             toByteBufferParams(queryParams),
-                            ThriftConversion.fromThrift(settings.command.consistencyLevel)));
+                            settings.command.consistencyLevel));
         }
 
         @Override
@@ -364,7 +365,7 @@ public abstract class CqlOperation<V> extends PredefinedOperation
         {
             String formattedQuery = formatCqlQuery(query, queryParams);
             return handler.simpleNativeHandler().apply(
-                    client.execute_cql3_query(formattedQuery, key, Compression.NONE, settings.command.consistencyLevel)
+                    client.execute_cql3_query(formattedQuery, key, Compression.NONE, ThriftConversion.toThrift(settings.command.consistencyLevel))
             );
         }
 
@@ -373,7 +374,7 @@ public abstract class CqlOperation<V> extends PredefinedOperation
         {
             Integer id = (Integer) preparedStatementId;
             return handler.simpleNativeHandler().apply(
-                    client.execute_prepared_cql3_query(id, key, toByteBufferParams(queryParams), settings.command.consistencyLevel)
+                    client.execute_prepared_cql3_query(id, key, toByteBufferParams(queryParams), ThriftConversion.toThrift(settings.command.consistencyLevel))
             );
         }
 

--- a/tools/stress/src/org/apache/cassandra/stress/operations/predefined/ThriftCounterAdder.java
+++ b/tools/stress/src/org/apache/cassandra/stress/operations/predefined/ThriftCounterAdder.java
@@ -35,6 +35,7 @@ import org.apache.cassandra.stress.util.ThriftClient;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.CounterColumn;
 import org.apache.cassandra.thrift.Mutation;
+import org.apache.cassandra.thrift.ThriftConversion;
 
 public class ThriftCounterAdder extends PredefinedOperation
 {
@@ -73,7 +74,7 @@ public class ThriftCounterAdder extends PredefinedOperation
             @Override
             public boolean run() throws Exception
             {
-                client.batch_mutate(record, settings.command.consistencyLevel);
+                client.batch_mutate(record, ThriftConversion.toThrift(settings.command.consistencyLevel));
                 return true;
             }
 

--- a/tools/stress/src/org/apache/cassandra/stress/operations/predefined/ThriftCounterGetter.java
+++ b/tools/stress/src/org/apache/cassandra/stress/operations/predefined/ThriftCounterGetter.java
@@ -29,6 +29,7 @@ import org.apache.cassandra.stress.settings.StressSettings;
 import org.apache.cassandra.stress.util.ThriftClient;
 import org.apache.cassandra.thrift.ColumnParent;
 import org.apache.cassandra.thrift.SlicePredicate;
+import org.apache.cassandra.thrift.ThriftConversion;
 
 public class ThriftCounterGetter extends PredefinedOperation
 {
@@ -46,7 +47,7 @@ public class ThriftCounterGetter extends PredefinedOperation
             @Override
             public boolean run() throws Exception
             {
-                List<?> r = client.get_slice(key, new ColumnParent(type.table), predicate, settings.command.consistencyLevel);
+                List<?> r = client.get_slice(key, new ColumnParent(type.table), predicate, ThriftConversion.toThrift(settings.command.consistencyLevel));
                 return r != null && r.size() > 0;
             }
 

--- a/tools/stress/src/org/apache/cassandra/stress/operations/predefined/ThriftInserter.java
+++ b/tools/stress/src/org/apache/cassandra/stress/operations/predefined/ThriftInserter.java
@@ -33,6 +33,7 @@ import org.apache.cassandra.stress.util.ThriftClient;
 import org.apache.cassandra.thrift.Column;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.Mutation;
+import org.apache.cassandra.thrift.ThriftConversion;
 import org.apache.cassandra.utils.FBUtilities;
 
 public final class ThriftInserter extends PredefinedOperation
@@ -68,7 +69,7 @@ public final class ThriftInserter extends PredefinedOperation
             @Override
             public boolean run() throws Exception
             {
-                client.batch_mutate(record, settings.command.consistencyLevel);
+                client.batch_mutate(record, ThriftConversion.toThrift(settings.command.consistencyLevel));
                 return true;
             }
 

--- a/tools/stress/src/org/apache/cassandra/stress/operations/predefined/ThriftReader.java
+++ b/tools/stress/src/org/apache/cassandra/stress/operations/predefined/ThriftReader.java
@@ -29,6 +29,7 @@ import org.apache.cassandra.stress.settings.StressSettings;
 import org.apache.cassandra.stress.util.ThriftClient;
 import org.apache.cassandra.thrift.ColumnOrSuperColumn;
 import org.apache.cassandra.thrift.ColumnParent;
+import org.apache.cassandra.thrift.ThriftConversion;
 
 public final class ThriftReader extends PredefinedOperation
 {
@@ -48,7 +49,7 @@ public final class ThriftReader extends PredefinedOperation
             @Override
             public boolean run() throws Exception
             {
-                List<ColumnOrSuperColumn> row = client.get_slice(key, new ColumnParent(type.table), select.predicate(), settings.command.consistencyLevel);
+                List<ColumnOrSuperColumn> row = client.get_slice(key, new ColumnParent(type.table), select.predicate(), ThriftConversion.toThrift(settings.command.consistencyLevel));
                 if (expect == null)
                     return !row.isEmpty();
                 if (row == null)

--- a/tools/stress/src/org/apache/cassandra/stress/operations/userdefined/SchemaQuery.java
+++ b/tools/stress/src/org/apache/cassandra/stress/operations/userdefined/SchemaQuery.java
@@ -52,10 +52,10 @@ public class SchemaQuery extends SchemaStatement
     final Object[][] randomBuffer;
     final Random random = new Random();
 
-    public SchemaQuery(Timer timer, StressSettings settings, PartitionGenerator generator, SeedManager seedManager, Integer thriftId, PreparedStatement statement, ConsistencyLevel cl, ArgSelect argSelect)
+    public SchemaQuery(Timer timer, StressSettings settings, PartitionGenerator generator, SeedManager seedManager, Integer thriftId, PreparedStatement statement, ArgSelect argSelect)
     {
         super(timer, settings, new DataSpec(generator, seedManager, new DistributionFixed(1), settings.insert.rowPopulationRatio.get(), argSelect == ArgSelect.MULTIROW ? statement.getVariables().size() : 1), statement,
-              statement.getVariables().asList().stream().map(d -> d.getName()).collect(Collectors.toList()), thriftId, cl);
+              statement.getVariables().asList().stream().map(d -> d.getName()).collect(Collectors.toList()), thriftId);
         this.argSelect = argSelect;
         randomBuffer = new Object[argumentIndex.length][argumentIndex.length];
     }
@@ -89,7 +89,7 @@ public class SchemaQuery extends SchemaStatement
 
         public boolean run() throws Exception
         {
-            CqlResult rs = client.execute_prepared_cql3_query(thriftId, partitions.get(0).getToken(), thriftArgs(), ThriftConversion.toThrift(cl));
+            CqlResult rs = client.execute_prepared_cql3_query(thriftId, partitions.get(0).getToken(), thriftArgs(), ThriftConversion.toThrift(ConsistencyLevel.valueOf(statement.getConsistencyLevel().toString())));
             rowCount = rs.getRowsSize();
             partitionCount = Math.min(1, rowCount);
             return true;

--- a/tools/stress/src/org/apache/cassandra/stress/operations/userdefined/SchemaStatement.java
+++ b/tools/stress/src/org/apache/cassandra/stress/operations/userdefined/SchemaStatement.java
@@ -29,39 +29,32 @@ import com.datastax.driver.core.ColumnDefinitions;
 import com.datastax.driver.core.DataType;
 import com.datastax.driver.core.LocalDate;
 import com.datastax.driver.core.PreparedStatement;
-import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.stress.generate.Row;
 import org.apache.cassandra.stress.operations.PartitionOperation;
 import org.apache.cassandra.stress.report.Timer;
 import org.apache.cassandra.stress.settings.StressSettings;
-import org.apache.cassandra.stress.util.JavaDriverClient;
 
 public abstract class SchemaStatement extends PartitionOperation
 {
     final PreparedStatement statement;
     final Integer thriftId;
-    final ConsistencyLevel cl;
     final int[] argumentIndex;
     final Object[] bindBuffer;
     final ColumnDefinitions definitions;
     final boolean printStatementsOnError;
     
     public SchemaStatement(Timer timer, StressSettings settings, DataSpec spec,
-                           PreparedStatement statement, List<String> bindNames, Integer thriftId, ConsistencyLevel cl)
+                           PreparedStatement statement, List<String> bindNames, Integer thriftId)
     {
         super(timer, settings, spec);
         this.statement = statement;
         this.thriftId = thriftId;
-        this.cl = cl;
         argumentIndex = new int[bindNames.size()];
         bindBuffer = new Object[argumentIndex.length];
         definitions = statement != null ? statement.getVariables() : null;
         int i = 0;
         for (String name : bindNames)
             argumentIndex[i++] = spec.partitionGenerator.indexOf(name);
-
-        if (statement != null)
-            statement.setConsistencyLevel(JavaDriverClient.from(cl));
         this.printStatementsOnError = settings.log.printStatementsOnError;
     }
 

--- a/tools/stress/src/org/apache/cassandra/stress/settings/SettingsCommand.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/SettingsCommand.java
@@ -32,7 +32,7 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.cassandra.stress.operations.OpDistributionFactory;
 import org.apache.cassandra.stress.util.JavaDriverClient;
 import org.apache.cassandra.stress.util.ResultLogger;
-import org.apache.cassandra.thrift.ConsistencyLevel;
+import org.apache.cassandra.db.ConsistencyLevel;
 
 // Generic command settings - common to read/write/etc
 public abstract class SettingsCommand implements Serializable
@@ -50,6 +50,7 @@ public abstract class SettingsCommand implements Serializable
     public final boolean noWarmup;
     public final TruncateWhen truncate;
     public final ConsistencyLevel consistencyLevel;
+    public final ConsistencyLevel serialConsistencyLevel;
     public final double targetUncertainty;
     public final int minimumUncertaintyMeasurements;
     public final int maximumUncertaintyMeasurements;
@@ -69,6 +70,7 @@ public abstract class SettingsCommand implements Serializable
     {
         this.type = type;
         this.consistencyLevel = ConsistencyLevel.valueOf(options.consistencyLevel.value().toUpperCase());
+        this.serialConsistencyLevel = ConsistencyLevel.valueOf(options.serialConsistencyLevel.value().toUpperCase());
         this.noWarmup = options.noWarmup.setByUser();
         this.truncate = TruncateWhen.valueOf(options.truncate.value().toUpperCase());
 
@@ -120,7 +122,8 @@ public abstract class SettingsCommand implements Serializable
     {
         final OptionSimple noWarmup = new OptionSimple("no-warmup", "", null, "Do not warmup the process", false);
         final OptionSimple truncate = new OptionSimple("truncate=", "never|once|always", "never", "Truncate the table: never, before performing any work, or before each iteration", false);
-        final OptionSimple consistencyLevel = new OptionSimple("cl=", "ONE|QUORUM|LOCAL_QUORUM|EACH_QUORUM|ALL|ANY|TWO|THREE|LOCAL_ONE", "LOCAL_ONE", "Consistency level to use", false);
+        final OptionSimple consistencyLevel = new OptionSimple("cl=", "ONE|QUORUM|LOCAL_QUORUM|EACH_QUORUM|ALL|ANY|TWO|THREE|LOCAL_ONE|SERIAL|LOCAL_SERIAL", "LOCAL_ONE", "Consistency level to use", false);
+        final OptionSimple serialConsistencyLevel = new OptionSimple("serial-cl=", "SERIAL|LOCAL_SERIAL", "SERIAL", "Serial consistency level to use", false);
     }
 
     static class Count extends Options
@@ -129,7 +132,7 @@ public abstract class SettingsCommand implements Serializable
         @Override
         public List<? extends Option> options()
         {
-            return Arrays.asList(count, noWarmup, truncate, consistencyLevel);
+            return Arrays.asList(count, noWarmup, truncate, consistencyLevel, serialConsistencyLevel);
         }
     }
 
@@ -139,7 +142,7 @@ public abstract class SettingsCommand implements Serializable
         @Override
         public List<? extends Option> options()
         {
-            return Arrays.asList(duration, noWarmup, truncate, consistencyLevel);
+            return Arrays.asList(duration, noWarmup, truncate, consistencyLevel, serialConsistencyLevel);
         }
     }
 
@@ -151,7 +154,7 @@ public abstract class SettingsCommand implements Serializable
         @Override
         public List<? extends Option> options()
         {
-            return Arrays.asList(uncertainty, minMeasurements, maxMeasurements, noWarmup, truncate, consistencyLevel);
+            return Arrays.asList(uncertainty, minMeasurements, maxMeasurements, noWarmup, truncate, consistencyLevel, serialConsistencyLevel);
         }
     }
 
@@ -183,6 +186,7 @@ public abstract class SettingsCommand implements Serializable
         }
         out.printf("  No Warmup: %s%n", noWarmup);
         out.printf("  Consistency Level: %s%n", consistencyLevel.toString());
+        out.printf("  Serial Consistency Level: %s%n", serialConsistencyLevel.toString());
         if (targetUncertainty != -1)
         {
             out.printf("  Target Uncertainty: %.3f%n", targetUncertainty);

--- a/tools/stress/src/org/apache/cassandra/stress/util/JavaDriverClient.java
+++ b/tools/stress/src/org/apache/cassandra/stress/util/JavaDriverClient.java
@@ -188,9 +188,31 @@ public class JavaDriverClient
         return getSession().execute(stmt);
     }
 
+    public ResultSet execute(String query, org.apache.cassandra.db.ConsistencyLevel consistency,
+                             org.apache.cassandra.db.ConsistencyLevel serialConsistency)
+    {
+        SimpleStatement stmt = new SimpleStatement(query);
+        if (consistency != null)
+            stmt.setConsistencyLevel(from(consistency));
+        if (serialConsistency != null)
+            stmt.setSerialConsistencyLevel(from(serialConsistency));
+        return getSession().execute(stmt);
+    }
+
     public ResultSet executePrepared(PreparedStatement stmt, List<Object> queryParams, org.apache.cassandra.db.ConsistencyLevel consistency)
     {
-        stmt.setConsistencyLevel(from(consistency));
+        if (stmt.getConsistencyLevel() == null)
+            stmt.setConsistencyLevel(from(consistency));
+        BoundStatement bstmt = stmt.bind((Object[]) queryParams.toArray(new Object[queryParams.size()]));
+        return getSession().execute(bstmt);
+    }
+
+    public ResultSet executePrepared(PreparedStatement stmt, List<Object> queryParams, org.apache.cassandra.db.ConsistencyLevel consistency, org.apache.cassandra.db.ConsistencyLevel serialConsistency )
+    {
+        if (stmt.getConsistencyLevel() == null)
+            stmt.setConsistencyLevel(from(consistency));
+        if (stmt.getSerialConsistencyLevel() == null)
+            stmt.setSerialConsistencyLevel(from(serialConsistency));
         BoundStatement bstmt = stmt.bind((Object[]) queryParams.toArray(new Object[queryParams.size()]));
         return getSession().execute(bstmt);
     }
@@ -224,6 +246,10 @@ public class JavaDriverClient
                 return com.datastax.driver.core.ConsistencyLevel.EACH_QUORUM;
             case LOCAL_ONE:
                 return com.datastax.driver.core.ConsistencyLevel.LOCAL_ONE;
+            case LOCAL_SERIAL:
+                return com.datastax.driver.core.ConsistencyLevel.LOCAL_SERIAL;
+            case SERIAL:
+                return com.datastax.driver.core.ConsistencyLevel.SERIAL;
         }
         throw new AssertionError();
     }


### PR DESCRIPTION
   Needed to be done in order to be able to control serial consistency and regular consistency levels separately
   For instance, it was not possible to set serial consistency to LOCAL_SERIAL and regular consistency to QUORUM.
   Now it is possible, and also it is possible to specify consistency in yaml file per query, in case you want to stress with dirrefent consistency levels.