### PR TITLE
reloc/build_deb.sh: Fix extra whitespace in"mv" command path

### DIFF
--- a/reloc/build_deb.sh
+++ b/reloc/build_deb.sh
@@ -31,7 +31,7 @@ done
 if [[ ! $OPTS =~ --reloc-pkg ]]; then
     OPTS="$OPTS --reloc-pkg $RELOC_PKG"
 fi
-rm -rf "$BUILDDIR "
+rm -rf "$BUILDDIR"
 mkdir -p "$BUILDDIR"/scylla-package
 tar -C "$BUILDDIR"/scylla-package -xpf $RELOC_PKG
 cd "$BUILDDIR"/scylla-package


### PR DESCRIPTION
Commit 40a65fbd63 ("reloc: Add "--builddir" option to
build_{rpm,deb}.sh") added extra whitespace in the "mv" command of
build_deb.sh. Let remove it to fix a build error.

Fixes #186