### PR TITLE
nodetool: Use non-default `cassandra.config`

### DIFF
--- a/bin/nodetool
+++ b/bin/nodetool
@@ -98,6 +98,7 @@ fi
         -Dcassandra.storagedir="$cassandra_storagedir" \
         -Dlogback.configurationFile=logback-tools.xml \
         $JVM_ARGS \
+        $CONFIGURATION_FILE_OPT \
         org.apache.cassandra.tools.NodeTool -p $JMX_PORT $ARGS
 
 # vi:ai sw=4 ts=4 tw=0 et

--- a/bin/scylla-sstableloader
+++ b/bin/scylla-sstableloader
@@ -42,6 +42,7 @@ if [ "x$MAX_HEAP_SIZE" = "x" ]; then
 fi
 
 "$JAVA" $JAVA_AGENT -ea -cp "$CLASSPATH" $JVM_OPTS -Xmx$MAX_HEAP_SIZE \
+        $CONFIGURATION_FILE_OPT \
         -Dcassandra.storagedir="$cassandra_storagedir" \
         -Dlogback.configurationFile=logback-tools.xml \
         com.scylladb.tools.BulkLoader "$@"

--- a/bin/sstablescrub
+++ b/bin/sstablescrub
@@ -42,6 +42,7 @@ if [ "x$MAX_HEAP_SIZE" = "x" ]; then
 fi
 
 "$JAVA" $JAVA_AGENT -ea -cp "$CLASSPATH" $JVM_OPTS -Xmx$MAX_HEAP_SIZE \
+        $CONFIGURATION_FILE_OPT \
         -Dcassandra.storagedir="$cassandra_storagedir" \
         -Dlogback.configurationFile=logback-tools.xml \
         org.apache.cassandra.tools.StandaloneScrubber "$@"

--- a/bin/sstableupgrade
+++ b/bin/sstableupgrade
@@ -42,6 +42,7 @@ if [ "x$MAX_HEAP_SIZE" = "x" ]; then
 fi
 
 "$JAVA" $JAVA_AGENT -ea -cp "$CLASSPATH" $JVM_OPTS -Xmx$MAX_HEAP_SIZE \
+        $CONFIGURATION_FILE_OPT \
         -Dcassandra.storagedir="$cassandra_storagedir" \
         -Dlogback.configurationFile=logback-tools.xml \
         org.apache.cassandra.tools.StandaloneUpgrader "$@"

--- a/bin/sstableutil
+++ b/bin/sstableutil
@@ -42,6 +42,7 @@ if [ "x$MAX_HEAP_SIZE" = "x" ]; then
 fi
 
 "$JAVA" $JAVA_AGENT -ea -cp "$CLASSPATH" $JVM_OPTS -Xmx$MAX_HEAP_SIZE \
+        $CONFIGURATION_FILE_OPT \
         -Dcassandra.storagedir="$cassandra_storagedir" \
         -Dlogback.configurationFile=logback-tools.xml \
         org.apache.cassandra.tools.StandaloneSSTableUtil "$@"

--- a/bin/sstableverify
+++ b/bin/sstableverify
@@ -42,6 +42,7 @@ if [ "x$MAX_HEAP_SIZE" = "x" ]; then
 fi
 
 "$JAVA" $JAVA_AGENT -ea -cp "$CLASSPATH" $JVM_OPTS -Xmx$MAX_HEAP_SIZE \
+        $CONFIGURATION_FILE_OPT \
         -Dcassandra.storagedir="$cassandra_storagedir" \
         -Dlogback.configurationFile=logback-tools.xml \
         org.apache.cassandra.tools.StandaloneVerifier "$@"


### PR DESCRIPTION
My understanding is that it should work, since this test: https://github.com/scylladb/scylla/issues/6878 has this log message: 

`Using /etc/scylla/scylla.yaml as the config file`

so the variable `CONFIG_FILE_REALPATH` is set and thus `CONFIGURATION_FILE_OPT` is also set. But an experiment is strongly advised.

Fixes scylladb/scylla#6878