### PR TITLE
dist: debian: do not require root during package build

### DIFF
--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -4,6 +4,7 @@ Priority: extra
 Maintainer: Takuya ASADA <syuu@scylladb.com>
 Homepage: http://www.scylladb.com
 Standards-Version: 3.9.5
+Rules-Requires-Root: no
 
 Package: %{product}-tools
 Architecture: all


### PR DESCRIPTION
Debian package builds provide a root environment for the installation
scripts, since that's what typical installation scripts expect. To
avoid providing actual root, a "fakeroot" system is used where syscalls
are intercepted and any effect that requires root (like chown) is emulated.

However, fakeroot sporadically fails for us, aborting the package build.
Since our install scripts don't really require root (when operating in
the --packaging mode), we can just tell dpkg-buildpackage that we don't
need fakeroot. This ought to fix the sporadic failures.

As a side effect, package builds are faster.

Follows scylla.git's b608af870b0a1ad88b91a72bddeff0c321877f9e.

Refs scylladb/scylla#6655.