### PR TITLE
dist: debian: support non-x86

### DIFF
--- a/dist/debian/build_deb.sh
+++ b/dist/debian/build_deb.sh
@@ -44,11 +44,6 @@ if [ ! -e scylla-tools/SCYLLA-RELOCATABLE-FILE ]; then
     exit 1
 fi
 
-if [ "$(arch)" != "x86_64" ]; then
-    echo "Unsupported architecture: $(arch)"
-    exit 1
-fi
-
 if is_debian_variant; then
     sudo apt-get -y update
 fi


### PR DESCRIPTION
The package is already arch independent, so remove the artifical
restriction to x86.