### PR TITLE
sstableloader: Preserve droppedColumns in column rename handling

### DIFF
--- a/src/java/com/scylladb/tools/ColumnNamesMapping.java
+++ b/src/java/com/scylladb/tools/ColumnNamesMapping.java
@@ -102,7 +102,9 @@ class ColumnNamesMapping {
                     break;
             }
         }
-        return CFMetaData.create(cfm.ksName, cfm.cfName, cfm.cfId, cfm.isDense(),
+        CFMetaData res = CFMetaData.create(cfm.ksName, cfm.cfName, cfm.cfId, cfm.isDense(),
                 cfm.isCompound(), cfm.isSuper(), cfm.isCounter(), cfm.isView(), columns, cfm.partitioner);
+        res.droppedColumns(cfm.getDroppedColumns());
+        return res;
     }
 }


### PR DESCRIPTION
Fixes #193

Columnnamesmapping replaces the schema fetched from cluster to
handle renaming of columns etc. It forgot to preserve droppedColumns,
where we deal with ignored columns.