### PR TITLE
sstableloader: remove wrong check that breaks range tombstones

### DIFF
--- a/src/java/com/scylladb/tools/SSTableToCQL.java
+++ b/src/java/com/scylladb/tools/SSTableToCQL.java
@@ -399,10 +399,6 @@ public class SSTableToCQL {
                     assert start.isInclusive();
                     where.put(column, Pair.create(Comp.Equal, sval));                                                              
                 } else {
-                    if (column.isPrimaryKeyColumn()) {
-                        // cannot generate <> for pk columns
-                        throw new IllegalStateException("Cannot generate <> comparison for primary key colum " + column);
-                    }
                     if (sval != null) {
                         where.put(column, 
                                 Pair.create( 


### PR DESCRIPTION
The check does not make sense because every column in the loop is a clustering
column so it's always part of primary key.
No range tombstone can pass this check.

Fixes #198

Signed-off-by: Piotr Jastrzebski <piotr@scylladb.com>