### PR TITLE
Relocatable Package: create product prefixed relocatable archive

### DIFF
--- a/dist/redhat/scylla-tools.spec
+++ b/dist/redhat/scylla-tools.spec
@@ -6,7 +6,7 @@ Group:          Applications/Databases
 
 License:        Apache
 URL:            http://www.scylladb.com/
-Source0:        scylla-tools-package.tar.gz
+Source0:        %{reloc_pkg}
 BuildArch:      noarch
 Requires:       %{product}-conf %{product}-tools-core
 Conflicts:      cassandra

--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -33,6 +33,11 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+VERSION=$(./SCYLLA-VERSION-GEN ${VERSION_OVERRIDE:+ --version "$VERSION_OVERRIDE"})
+# the former command should generate build/SCYLLA-PRODUCT-FILE and some other version
+# related files
+PRODUCT=`cat build/SCYLLA-PRODUCT-FILE`
+
 is_redhat_variant() {
     [ -f /etc/redhat-release ]
 }
@@ -50,16 +55,15 @@ if [ "$CLEAN" = "yes" ]; then
     rm -rf build target
 fi
 
-if [ -f build/scylla-tools-package.tar.gz ]; then
-    rm build/scylla-tools-package.tar.gz
+if [ -f build/$PRODUCT-tools-package.tar.gz ]; then
+    rm build/$PRODUCT-tools-package.tar.gz
 fi
 
 if [ -z "$NODEPS" ]; then
     sudo ./install-dependencies.sh
 fi
 
-VERSION=$(./SCYLLA-VERSION-GEN ${VERSION_OVERRIDE:+ --version "$VERSION_OVERRIDE"})
 printf "version=%s" $VERSION > build.properties
 ant jar
 dist/debian/debian_files_gen.py
-scripts/create-relocatable-package.py --version $VERSION build/scylla-tools-package.tar.gz
+scripts/create-relocatable-package.py --version $VERSION build/$PRODUCT-tools-package.tar.gz

--- a/reloc/build_rpm.sh
+++ b/reloc/build_rpm.sh
@@ -31,6 +31,7 @@ mkdir -p "$BUILDDIR"
 tar -C "$BUILDDIR" -xpf $RELOC_PKG scylla-tools/SCYLLA-RELEASE-FILE scylla-tools/SCYLLA-RELOCATABLE-FILE scylla-tools/SCYLLA-VERSION-FILE scylla-tools/SCYLLA-PRODUCT-FILE scylla-tools/dist/redhat
 cd "$BUILDDIR"/scylla-tools
 
+RELOC_PKG_BASENAME=$(basename "$RELOC_PKG")
 SCYLLA_VERSION=$(cat SCYLLA-VERSION-FILE)
 SCYLLA_RELEASE=$(cat SCYLLA-RELEASE-FILE)
 VERSION=$SCYLLA_VERSION-$SCYLLA_RELEASE
@@ -44,6 +45,7 @@ parameters=(
     -D"version $SCYLLA_VERSION"
     -D"release $SCYLLA_RELEASE"
     -D"product $PRODUCT"
+    -D"reloc_pkg $RELOC_PKG_BASENAME"
 )
 
 cp dist/redhat/scylla-tools.spec $RPMBUILD/SPECS


### PR DESCRIPTION
The build system was hardcoded to produce a package that is
prefixed with scylla instead of the product name. This is not
in line with out CI system requirements and can be also a source
for confusion.
This commit make the packaging system generate a package of
the format: {product}-tools-package.tar.gz instead of
scylla-tools-package.tar.gz