### PR TITLE
sstableloader: Fix command line parsing of "ignore-missing-columns"

### DIFF
--- a/src/java/com/scylladb/tools/BulkLoader.java
+++ b/src/java/com/scylladb/tools/BulkLoader.java
@@ -1209,7 +1209,7 @@ public class BulkLoader {
                     opts.setAllColumns = true;
                 }
                 if (cmd.hasOption(IGNORE_MISSING_COLUMNS)) {
-                    opts.ignoreColumns.addAll(Arrays.asList(cmd.getOptionValues(IGNORE_MISSING_COLUMNS)));
+                    opts.ignoreColumns.addAll(Arrays.asList(cmd.getOptionValue(IGNORE_MISSING_COLUMNS).split(",")));
                 }
                 if (cmd.hasOption(IGNORE_DROPPED_COUNTER_DATA)) {
                     opts.ignoreDroppedCounterData = true;


### PR DESCRIPTION
Fixes #214

The arg parser API call 'getOptionValues' does not quite do what
we hoped. Just do manual splitting instead.