### PR TITLE
sstableloader: Only escape column names once

### DIFF
--- a/src/java/com/scylladb/tools/BulkLoader.java
+++ b/src/java/com/scylladb/tools/BulkLoader.java
@@ -45,6 +45,7 @@ import static com.datastax.driver.core.Cluster.builder;
 import static com.scylladb.tools.BulkLoader.Verbosity.Normal;
 import static com.scylladb.tools.SSTableToCQL.TIMESTAMP_VAR_NAME;
 import static com.scylladb.tools.SSTableToCQL.TTL_VAR_NAME;
+import static com.scylladb.tools.SSTableToCQL.cqlEscape;
 import static java.lang.Thread.currentThread;
 import static org.apache.cassandra.io.sstable.format.SSTableReader.openForBatch;
 import static org.apache.cassandra.schema.CQLTypeParser.parse;
@@ -369,7 +370,7 @@ public class BulkLoader {
 
             cluster = builder.build();
 
-            String escaped = "\"" + keyspace + "\"";
+            String escaped = cqlEscape(keyspace);
             session = cluster.connect(escaped);
             metadata = cluster.getMetadata();
             keyspaceMetadata = metadata.getKeyspace(escaped);
@@ -688,8 +689,8 @@ public class BulkLoader {
             Pair<String, String> key = Pair.create(keyspace, cfName);
             CFMetaData cfm = cfMetaDatas.get(key);
             if (cfm == null) {
-                KeyspaceMetadata ks = metadata.getKeyspace("\"" + keyspace + "\"");
-                TableMetadata cf = ks.getTable("\"" + cfName + "\"");
+                KeyspaceMetadata ks = metadata.getKeyspace(cqlEscape(keyspace));
+                TableMetadata cf = ks.getTable(cqlEscape(cfName));
                 if (cf == null) {
                     throw new IllegalArgumentException("Could not find table named " + keyspace + "." + cfName);
                 }

--- a/src/java/com/scylladb/tools/SSTableToCQL.java
+++ b/src/java/com/scylladb/tools/SSTableToCQL.java
@@ -57,8 +57,8 @@ import org.apache.cassandra.db.marshal.TupleType;
 import org.apache.cassandra.db.rows.Cell;
 import org.apache.cassandra.db.rows.ColumnData;
 import org.apache.cassandra.db.rows.ComplexColumnData;
-import org.apache.cassandra.db.rows.RangeTombstoneBoundaryMarker;
 import org.apache.cassandra.db.rows.RangeTombstoneBoundMarker;
+import org.apache.cassandra.db.rows.RangeTombstoneBoundaryMarker;
 import org.apache.cassandra.db.rows.RangeTombstoneMarker;
 import org.apache.cassandra.db.rows.Row;
 import org.apache.cassandra.db.rows.Row.Deletion;
@@ -101,6 +101,10 @@ import com.google.common.collect.MultimapBuilder;
 public class SSTableToCQL {
     public static final String TIMESTAMP_VAR_NAME = "timestamp";
     public static final String TTL_VAR_NAME = "ttl";
+
+    public static String cqlEscape(String id) {
+        return "\"" + id + "\"";
+    }
 
     public static class Options {
         public boolean setAllColumns;
@@ -154,7 +158,7 @@ public class SSTableToCQL {
                 String name = columnName(c);
                 String varName = varName(c);
                 params.put(name, Collections.singleton(key));
-                return " = \"" + name + "\" - :" + varName;
+                return " = " + cqlEscape(name) + " - :" + varName;
             }
 
             @Override
@@ -258,7 +262,7 @@ public class SSTableToCQL {
                 String name = columnName(c);
                 String varName = varName(c);
                 params.put(varName, Collections.singleton(key));
-                return " = \"" + name + "\" + :" + varName;
+                return " = " + cqlEscape(name) + " + :" + varName;
             }
 
             @Override
@@ -945,16 +949,14 @@ public class SSTableToCQL {
         }
 
         private void writeColumnName(StringBuilder buf, ColumnDefinition c) {
-            buf.append('\"');
-            buf.append(columnName(c));
-            buf.append('\"');
+            buf.append(columnName(c)); // already escaped!
         }
         private void writeColumnFamily(StringBuilder buf) {
-            buf.append(" \"");
-            buf.append(cfMetaData.ksName);
-            buf.append("\".\"");
-            buf.append(cfMetaData.cfName);
-            buf.append("\" ");
+            buf.append(" ");
+            buf.append(cqlEscape(cfMetaData.ksName));
+            buf.append(".");
+            buf.append(cqlEscape(cfMetaData.cfName));
+            buf.append(" ");
         }
     }
 


### PR DESCRIPTION
Fixes #220

Old code did explicit escaping after calling "columnamemappings.getName",
however this method already interns the name -> escapes it.
Adding yet another unconditional quote just breaks cql syntax.

Also move escaping to single routine to better deal with these things.