### PR TITLE
cassandra.in.sh: remove debug message

### DIFF
--- a/dist/common/cassandra.in.sh
+++ b/dist/common/cassandra.in.sh
@@ -8,7 +8,6 @@ CASSANDRA_CONF="$SCYLLA_CONF/cassandra"
 # or place us there.
 
 CONFIG_FILE_REALPATH=`realpath $SCYLLA_CONF/scylla.yaml`
-echo "Using $CONFIG_FILE_REALPATH as the config file"
 CONFIGURATION_FILE_OPT="-Dcassandra.config=file://$CONFIG_FILE_REALPATH"
 
 CASSANDRA_HOME=/opt/scylladb/share/cassandra

--- a/tools/bin/cassandra.in.sh
+++ b/tools/bin/cassandra.in.sh
@@ -60,7 +60,6 @@ if [ -f "$SCYLLA_CONF/scylla.yaml" ]; then
     CONFIG_FILE_REALPATH=`realpath $SCYLLA_CONF/scylla.yaml`
 fi
 
-echo "Using $CONFIG_FILE_REALPATH as the config file"
 CONFIGURATION_FILE_OPT="-Dcassandra.config=file://$CONFIG_FILE_REALPATH"
 
 # The java classpath (required)


### PR DESCRIPTION
Apparently, some automation tools rely on the output, so debug messages are out of place here.

Fixes #213