### PR TITLE
nodetool: Make toppartitions call the generic endpoint

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -28,6 +28,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import javax.management.NotificationEmitter;
+import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.OpenDataException;
 import javax.management.openmbean.TabularData;
 
 public interface StorageServiceMBean extends NotificationEmitter
@@ -670,6 +672,8 @@ public interface StorageServiceMBean extends NotificationEmitter
 
     /** Sets the hinted handoff throttle in kb per second, per delivery thread. */
     public void setHintedHandoffThrottleInKB(int throttleInKB);
+
+    public CompositeData getToppartitions(String sampler, List<String> keyspaceFilters, List<String> tableFilters, int duration, int capacity, int count) throws OpenDataException;
 
     /**
      * Resume bootstrap streaming when there is failed data streaming.

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -480,6 +480,18 @@ public class NodeProbe implements AutoCloseable
         return result;
     }
 
+    public Map<Sampler, CompositeData> getToppartitions(List<String> keyspaceFilters, List<String> tableFilters, int capacity, int duration, int count, List<Sampler> samplers) throws OpenDataException
+    {
+        Map<Sampler, CompositeData> result = Maps.newHashMap();
+
+        for (Sampler sampler : samplers)
+        {
+            result.put(sampler, ssProxy.getToppartitions(sampler.name(), keyspaceFilters, tableFilters, duration, capacity, count));
+        }
+
+        return result;
+    }
+
     public void invalidateCounterCache()
     {
         cacheService.invalidateCounterCache();


### PR DESCRIPTION
This change switches the toppartitions call to address
the generic JMX endpoint introduced in scylladb/scylla-jmx#157
It now makes it possible to query multiple tables
and keyspaces for the top partitions of the whole group.