### PR TITLE
cassandra-stress: fix failure due to the assert exception on disconnect when test is completed

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/util/JavaDriverClient.java
+++ b/tools/stress/src/org/apache/cassandra/stress/util/JavaDriverClient.java
@@ -256,6 +256,12 @@ public class JavaDriverClient
 
     public void disconnect()
     {
-        cluster.close();
+        try {
+            cluster.close();
+        } catch (Exception e) {
+            System.out.printf(
+                    "Failed to close connection due to the following error: %s",
+                    e.toString());
+        }
     }
 }


### PR DESCRIPTION
When test is completed c-s closes connection to the cluster.
due to the bug in driver it can fail there with assertException:

java.lang.AssertionError
        at com.datastax.driver.core.ConvictionPolicy$DefaultConvictionPolicy.signalConnectionClosed(ConvictionPolicy.java:90)
        at com.datastax.driver.core.Connection.closeAsync(Connection.java:953)
        at com.datastax.driver.core.HostConnectionPool.discardAvailableConnections(HostConnectionPool.java:882)
        at com.datastax.driver.core.HostConnectionPool.closeAsync(HostConnectionPool.java:843)