### PR TITLE
cassandra.in.sh: Add path to rack/dc properties file to classpath

### DIFF
--- a/dist/common/cassandra.in.sh
+++ b/dist/common/cassandra.in.sh
@@ -27,7 +27,7 @@ for jar in /opt/scylladb/share/cassandra/*.jar; do
     CLASSPATH=$CLASSPATH:$jar
 done
 
-CLASSPATH="$CLASSPATH:$EXTRA_CLASSPATH"
+CLASSPATH="$CLASSPATH:$SCYLLA_CONF:$EXTRA_CLASSPATH"
 
 # set JVM javaagent opts to avoid warnings/errors
 if [ "$JVM_VENDOR" != "OpenJDK" -o "$JVM_VERSION" \> "1.6.0" ] \


### PR DESCRIPTION
Otherwise, when using `GossipingPropertyFileSnitch`, nodetool would not find it. On installed scylla this file is typically located in `$SCYLLA_CONF`, next to `scylla.yaml`.

Refs scylladb/scylla#7930