### PR TITLE
sstableloader: Handle non-prepared batches with ":" in identifier names

### DIFF
--- a/src/java/com/scylladb/tools/BulkLoader.java
+++ b/src/java/com/scylladb/tools/BulkLoader.java
@@ -798,7 +798,9 @@ public class BulkLoader {
             }
         }
 
-        private static final Pattern variable = Pattern.compile("\\:(\\w+)");
+        // #241 - cql table identifiers can have names with ":" in them.
+        // In that case, it should be escaped by now. Need to match against this.
+        private static final Pattern variable = Pattern.compile("(?<=[^\"]|^)\\:(\\w+)(?=[^\"]|$)");
 
         private void send(DecoratedKey key, long timestamp, String what, Map<String, Object> objects, boolean allowBatch) {
             SimpleStatement s;


### PR DESCRIPTION
Because non-prepared batch statements cannot handle named variables,
we do variable replacement in this mode (terrible, yes). The regex
match does not deal with column/keyspace/table identifiers containing
":" (i.e. alternator).

Need to do boundary match (lookahead/lookbehind).