### PR TITLE
Add EverywhereStrategy class

### DIFF
--- a/src/java/org/apache/cassandra/locator/EverywhereStrategy.java
+++ b/src/java/org/apache/cassandra/locator/EverywhereStrategy.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 ScyllaDB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.locator;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.dht.Token;
+
+
+/**
+ * This class returns all the nodes
+ */
+public class EverywhereStrategy extends AbstractReplicationStrategy
+{
+    private final TokenMetadata metadata;
+
+    public EverywhereStrategy(String keyspaceName, TokenMetadata tokenMetadata, IEndpointSnitch snitch, Map<String, String> configOptions)
+    {
+        super(keyspaceName, tokenMetadata, snitch, configOptions);
+        metadata = tokenMetadata;
+    }
+
+    public List<InetAddress> calculateNaturalEndpoints(Token token, TokenMetadata metadata)
+    {
+        return new ArrayList<>(metadata.getAllEndpoints());
+    }
+
+    public int getReplicationFactor()
+    {
+        return metadata.getAllEndpoints().size();
+    }
+
+    public void validateOptions() throws ConfigurationException
+    {
+    }
+
+    public Collection<String> recognizedOptions()
+    {
+        return Collections.<String>emptyList();
+    }
+}


### PR DESCRIPTION
5 years ago a new replication strategy was implemented for Scylla in
https://github.com/scylladb/scylla/commit/cc30956c561f0e4b380823e7930d857c9eb2db72

However the tools were never updated to support it.

Recently a new system keyspace that uses this Everywhere replication
strategy was added to Scylla in
https://github.com/scylladb/scylla/commit/617813ba66733ddcca82ac1155247952e73c59d0

This caused offline_tools_test.TestOfflineTools.sstablelevelreset_test dtests to fail with:
'ColumnFamily not found: keyspace1/standard1' not found in
"org.apache.cassandra.exceptions.ConfigurationException: Unable to find
replication strategy class
'org.apache.cassandra.locator.EverywhereStrategy'\n\tat
org.apache.cassandra.utils.FBUtilities.classForName(FBUtilities.java:504)\n\tat
org.apache.cassandra.locator.AbstractReplicationStrategy.getClass(AbstractReplicationStrategy.java:295)\n\tat
org.apache.cassandra.schema.ReplicationParams.fromMap(ReplicationParams.java:81)\n\tat
org.apache.cassandra.schema.KeyspaceParams.create(KeyspaceParams.java:64)\n\tat
org.apache.cassandra.schema.SchemaKeyspace.fetchKeyspaceParams(SchemaKeyspace.java:970)\n\tat
org.apache.cassandra.schema.SchemaKeyspace.fetchKeyspace(SchemaKeyspace.java:955)\n\tat
org.apache.cassandra.schema.SchemaKeyspace.fetchKeyspacesWithout(SchemaKeyspace.java:934)\n\tat
org.apache.cassandra.schema.SchemaKeyspace.fetchNonSystemKeyspaces(SchemaKeyspace.java:922)\n\tat
org.apache.cassandra.config.Schema.loadFromDisk(Schema.java:92)\n\tat
org.apache.cassandra.config.Schema.loadFromDiskForTool(Schema.java:101)\n\tat
org.apache.cassandra.tools.SSTableLevelResetter.main(SSTableLevelResetter.java:67)\nCaused
by: java.lang.ClassNotFoundException:
org.apache.cassandra.locator.EverywhereStrategy\n\tat
java.net.URLClassLoader.findClass(URLClassLoader.java:382)\n\tat
java.lang.ClassLoader.loadClass(ClassLoader.java:424)\n\tat
sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)\n\tat
java.lang.ClassLoader.loadClass(ClassLoader.java:357)\n\tat
java.lang.Class.forName0(Native Method)\n\tat
java.lang.Class.forName(Class.java:264)\n\tat
org.apache.cassandra.utils.FBUtilities.classForName(FBUtilities.java:500)\n\t...
10 more\n"

This commit fixes that.

Fixes #246 

Signed-off-by: Piotr Jastrzebski <piotr@scylladb.com>