### PR TITLE
cassandra-stress: Remove maxPendingPerConnection default

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/settings/SettingsMode.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/SettingsMode.java
@@ -164,7 +164,7 @@ public class SettingsMode implements Serializable
         final OptionSimple user = new OptionSimple("user=", ".+", null, "username", false);
         final OptionSimple password = new OptionSimple("password=", ".+", null, "password", false);
         final OptionSimple authProvider = new OptionSimple("auth-provider=", ".*", null, "Fully qualified implementation of com.datastax.driver.core.AuthProvider", false);
-        final OptionSimple maxPendingPerConnection = new OptionSimple("maxPending=", "[0-9]+", "128", "Maximum pending requests per connection", false);
+        final OptionSimple maxPendingPerConnection = new OptionSimple("maxPending=", "[0-9]+", null, "Maximum pending requests per connection", false);
         final OptionSimple connectionsPerHost = new OptionSimple("connectionsPerHost=", "[0-9]+", "8", "Number of connections per host", false);
 
         abstract OptionSimple mode();

--- a/tools/stress/src/org/apache/cassandra/stress/util/JavaDriverClient.java
+++ b/tools/stress/src/org/apache/cassandra/stress/util/JavaDriverClient.java
@@ -46,7 +46,7 @@ public class JavaDriverClient
     public final String username;
     public final String password;
     public final AuthProvider authProvider;
-    public final int maxPendingPerConnection;
+    public final Integer maxPendingPerConnection;
     public final int connectionsPerHost;
 
     private final ProtocolVersion protocolVersion;
@@ -84,7 +84,7 @@ public class JavaDriverClient
         //See https://issues.apache.org/jira/browse/CASSANDRA-7217
         int requestsPerConnection = (maxThreadCount / connectionsPerHost) + connectionsPerHost;
 
-        maxPendingPerConnection = settings.mode.maxPendingPerConnection == null ? Math.max(128, requestsPerConnection ) : settings.mode.maxPendingPerConnection;
+        maxPendingPerConnection = settings.mode.maxPendingPerConnection;
     }
 
     private LoadBalancingPolicy loadBalancingPolicy(StressSettings settings)
@@ -123,8 +123,10 @@ public class JavaDriverClient
     {
         PoolingOptions poolingOpts = new PoolingOptions()
                                      .setConnectionsPerHost(HostDistance.LOCAL, connectionsPerHost, connectionsPerHost)
-                                     .setMaxRequestsPerConnection(HostDistance.LOCAL, maxPendingPerConnection)
                                      .setNewConnectionThreshold(HostDistance.LOCAL, 100);
+        if (maxPendingPerConnection != null) {
+            poolingOpts.setMaxRequestsPerConnection(HostDistance.LOCAL, maxPendingPerConnection);
+        }
 
         Cluster.Builder clusterBuilder = Cluster.builder()
                                                 .addContactPoint(host)


### PR DESCRIPTION
cassandra-stress uses 128 as a default for maxPendingPerConnection.
This is very wrong. 128 used to be the default value in the driver
up to the version 3 of the protocol. Since V3 the default is 1024.

The behaviour of cassandra-stress has caused driver to throw
BusyPoolException because each connection was limited to only 128
inflight requests. For more info see:
https://github.com/scylladb/scylla/issues/7748

This patch removes the default maxPendingPerConnection value from
cassandra-stress. This way driver will decide on its own what's the
appropriate default depending on the version of the CQL protocol used.

Fixes https://github.com/scylladb/scylla/issues/7748

Signed-off-by: Piotr Jastrzebski <piotr@scylladb.com>