### PR TITLE
reloc: add arch to relocatable package filename

### DIFF
--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -66,4 +66,4 @@ fi
 printf "version=%s" $VERSION > build.properties
 ant jar
 dist/debian/debian_files_gen.py
-scripts/create-relocatable-package.py --version $VERSION build/$PRODUCT-tools-package.tar.gz
+scripts/create-relocatable-package.py --version $VERSION build/$PRODUCT-tools-$(arch)-package.tar.gz


### PR DESCRIPTION
Add architecture name for relocatable packages, to support distributing
both x86_64 version and aarch64 version.

See scylladb/scylla#8675