### PR TITLE
node_probe: toppartitions: Fix wrong class in getMethod

### DIFF
--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -488,7 +488,7 @@ public class NodeProbe implements AutoCloseable
         try
         {
             Class[] cArg = new Class[6];
-            cArg[0] = cArg[1] = cArg[2] = (Class<List<String>>) Collections.<String>emptyList().getClass();
+            cArg[0] = cArg[1] = cArg[2] = List.class;
             cArg[3] = cArg[4] = cArg[5] = int.class;
 
             // make sure that JMX has the newer API, throws NoSuchMethodException if not


### PR DESCRIPTION
We check for the existence of the new toppartitions JMX API
using Class.getMethod, but use wrong class for List<String>
in parameter list. This change fixes that.