### PR TITLE
Fix NullPointerException in SettingsMode

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/settings/SettingsMode.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/SettingsMode.java
@@ -164,7 +164,7 @@ public class SettingsMode implements Serializable
         final OptionSimple user = new OptionSimple("user=", ".+", null, "username", false);
         final OptionSimple password = new OptionSimple("password=", ".+", null, "password", false);
         final OptionSimple authProvider = new OptionSimple("auth-provider=", ".*", null, "Fully qualified implementation of com.datastax.driver.core.AuthProvider", false);
-        final OptionSimple maxPendingPerConnection = new OptionSimple("maxPending=", "[0-9]+", null, "Maximum pending requests per connection", false);
+        final OptionSimple maxPendingPerConnection = new OptionSimple("maxPending=", "[0-9]+", "", "Maximum pending requests per connection", false);
         final OptionSimple connectionsPerHost = new OptionSimple("connectionsPerHost=", "[0-9]+", "8", "Number of connections per host", false);
 
         abstract OptionSimple mode();


### PR DESCRIPTION
After 6fa38389320661e10c34d03daf328c9d8b5f3445 it was possible for
SettingsMode to try to use null object.

Fixes #257