### PR TITLE
dist/redhat: change PyYAML filepath to allow installing on SLES15

### DIFF
--- a/dist/redhat/scylla-tools.spec
+++ b/dist/redhat/scylla-tools.spec
@@ -26,7 +26,7 @@ Requires:       jre-1.8.0-headless python2
 # Since RHEL7 and RHEL8 has different pacakge name for pyyaml,
 # we need to use a file path to the resolve package name on
 # current distribution.
-Requires:       /usr/lib64/python2.7/site-packages/_yaml.so
+Requires:       /usr/lib64/python2.7/site-packages/yaml/__init__.py
 
 %global __brp_python_bytecompile %{nil}
 %global __brp_mangle_shebangs %{nil}


### PR DESCRIPTION
It seems like PyYAML package on SLES15 does not have _yaml.so,
we need to use other file to specify the package.

Fixes scylladb/scylla#9045