### PR TITLE
nodetool: support validate

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -2983,6 +2983,16 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         return status.statusCode;
     }
 
+    public int validate(String keyspaceName, String... tables) throws IOException, ExecutionException, InterruptedException
+    {
+        return validate(0, keyspaceName, tables);
+    }
+
+    public int validate(int jobs, String keyspaceName, String... tables) throws IOException, ExecutionException, InterruptedException
+    {
+        throw new RuntimeException("Validate is not implemented");
+    }
+
     public int scrub(boolean disableSnapshot, boolean skipCorrupted, String keyspaceName, String... tables) throws IOException, ExecutionException, InterruptedException
     {
         return scrub(disableSnapshot, skipCorrupted, true, 0, keyspaceName, tables);

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -270,6 +270,19 @@ public interface StorageServiceMBean extends NotificationEmitter
     public int forceKeyspaceCleanup(int jobs, String keyspaceName, String... tables) throws IOException, ExecutionException, InterruptedException;
 
     /**
+     * Run validation compaction of tables in a single keyspace.
+     * If tables array is empty, all tables are validated.
+     *
+     * This is essentially a read-only version of scrub.
+     */
+    @Deprecated
+    public int validate(String keyspaceName, String... tables)
+            throws IOException, ExecutionException, InterruptedException;
+
+    public int validate(int jobs, String keyspaceName, String... tables)
+            throws IOException, ExecutionException, InterruptedException;
+
+    /**
      * Scrub (deserialize + reserialize at the latest version, skipping bad rows if any) the given keyspace.
      * If tableNames array is empty, all CFs are scrubbed.
      *

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -312,6 +312,11 @@ public class NodeProbe implements AutoCloseable
         return ssProxy.forceKeyspaceCleanup(jobs, keyspaceName, tables);
     }
 
+    public int validate(int jobs, String keyspaceName, String... tables) throws IOException, ExecutionException, InterruptedException
+    {
+        return ssProxy.validate(jobs, keyspaceName, tables);
+    }
+
     public int scrub(boolean disableSnapshot, boolean skipCorrupted, boolean checkData, boolean reinsertOverflowedTTL, int jobs, String keyspaceName, String... tables) throws IOException, ExecutionException, InterruptedException
     {
         return ssProxy.scrub(disableSnapshot, skipCorrupted, checkData, reinsertOverflowedTTL, jobs, keyspaceName, tables);
@@ -352,6 +357,22 @@ public class NodeProbe implements AutoCloseable
             case 2:
                 failed = true;
                 out.println("Failed marking some sstables compacting in keyspace "+keyspaceName+", check server logs for more information");
+                break;
+        }
+    }
+
+    public void validate(PrintStream out, int jobs, String keyspaceName, String... tableNames) throws IOException, ExecutionException, InterruptedException
+    {
+        checkJobs(out, jobs);
+        switch (validate(jobs, keyspaceName, tableNames))
+        {
+            case 1:
+                failed = true;
+                out.println("Aborted validation at least one table in keyspace "+keyspaceName+", check server logs for more information.");
+                break;
+            case 2:
+                failed = true;
+                out.println("Failed validation of some sstables in keyspace "+keyspaceName+", check server logs for more information");
                 break;
         }
     }

--- a/src/java/org/apache/cassandra/tools/NodeTool.java
+++ b/src/java/org/apache/cassandra/tools/NodeTool.java
@@ -66,6 +66,7 @@ public class NodeTool
                 Cleanup.class,
                 ClearSnapshot.class,
                 Compact.class,
+                Validate.class,
                 Scrub.class,
                 // Remove until proven otherwise: Verify.class,
                 Flush.class,

--- a/src/java/org/apache/cassandra/tools/nodetool/Validate.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Validate.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2021-present ScyllaDB
+ */
+
+ /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.tools.nodetool;
+
+import io.airlift.command.Arguments;
+import io.airlift.command.Command;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.airlift.command.Option;
+import org.apache.cassandra.config.SchemaConstants;
+import org.apache.cassandra.tools.NodeProbe;
+import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
+
+@Command(name = "validate", description = "Triggers validation of tables. By default, validate all keyspaces")
+public class Validate extends NodeToolCmd
+{
+    @Arguments(usage = "[<keyspace> [<tables>...]]", description = "A keyspace, optionally followed by one or many tables")
+    private List<String> args = new ArrayList<>();
+
+    @Option(title = "jobs",
+            name = {"-j", "--jobs"},
+            description = "Number of tables to cleanup simultanously, set to 0 to use all available compaction threads")
+    private int jobs = 0;
+
+    @Override
+    public void execute(NodeProbe probe)
+    {
+        List<String> keyspaces = parseOptionalKeyspace(args, probe, KeyspaceSet.NON_LOCAL_STRATEGY);
+        String[] tableNames = parseOptionalTables(args);
+
+        for (String keyspace : keyspaces)
+        {
+            if (SchemaConstants.isLocalSystemKeyspace(keyspace))
+                continue;
+
+            try
+            {
+                probe.validate(System.out, jobs, keyspace, tableNames);
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException("Error occurred during validation", e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add support for `nodetool validate [ks [cf...]]`
Based on the api added in scylladb/scylla@b0ef57c83390ada3152568f06769ad76c596cb5e

Depends on https://github.com/scylladb/scylla-jmx/pull/173

Fixes #263

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>