### PR TITLE
nodetool: add `--load-and-stream` option to `refresh`

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -5085,7 +5085,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     /**
      * #{@inheritDoc}
      */
-    public void loadNewSSTables(String ksName, String cfName)
+    public void loadNewSSTables(String ksName, String cfName, boolean isLoadAndStream)
     {
         if (!isInitialized())
             throw new RuntimeException("Not yet initialized, can't load new sstables");

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -615,8 +615,9 @@ public interface StorageServiceMBean extends NotificationEmitter
      *
      * @param ksName The parent keyspace name
      * @param tableName The ColumnFamily name where SSTables belong
+     * @param isLoadAndStream Whether or not arbitrary SSTables should be loaded (and streamed to the owning nodes)
      */
-    public void loadNewSSTables(String ksName, String tableName);
+    public void loadNewSSTables(String ksName, String tableName, boolean isLoadAndStream);
 
     /**
      * Return a List of Tokens representing a sample of keys across all ColumnFamilyStores.

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -1217,9 +1217,9 @@ public class NodeProbe implements AutoCloseable
         return msProxy.getDroppedMessages();
     }
 
-    public void loadNewSSTables(String ksName, String cfName)
+    public void loadNewSSTables(String ksName, String cfName, boolean isLoadAndStream)
     {
-        ssProxy.loadNewSSTables(ksName, cfName);
+        ssProxy.loadNewSSTables(ksName, cfName, isLoadAndStream);
     }
 
     public void rebuildIndex(String ksName, String cfName, String... idxNames)

--- a/src/java/org/apache/cassandra/tools/nodetool/Refresh.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Refresh.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.tools.nodetool;
 import static com.google.common.base.Preconditions.checkArgument;
 import io.airlift.command.Arguments;
 import io.airlift.command.Command;
+import io.airlift.command.Option;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,10 +34,15 @@ public class Refresh extends NodeToolCmd
     @Arguments(usage = "<keyspace> <table>", description = "The keyspace and table name")
     private List<String> args = new ArrayList<>();
 
+    @Option(title = "load-and-stream",
+    name = {"-las", "--load-and-stream"},
+    description = "Allows loading sstables that do not belong to this node, in which case they are automatically streamed to the owning nodes.")
+    private boolean isLoadAndStream = false;
+
     @Override
     public void execute(NodeProbe probe)
     {
         checkArgument(args.size() == 2, "refresh requires ks and cf args");
-        probe.loadNewSSTables(args.get(0), args.get(1));
+        probe.loadNewSSTables(args.get(0), args.get(1), isLoadAndStream);
     }
 }


### PR DESCRIPTION
This information is forwarded through JMX to Scylla, adding an extra
{"load_and_stream", "true"} entry in the POST request to Scylla's HTTP API
at `storage_service/sstables/{keyspace}` endpoint.

More about this feature: scylladb/scylla#7846
Mutually bonded change: scylladb/scylla-jmx#176
Fixes #253