### PR TITLE
reloc/build_reloc.sh: Add missing space

### DIFF
--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -67,7 +67,7 @@ printf "version=%s" $VERSION > build.properties
 
 # Our ant build.xml requires JAVA8_HOME to be set. In case it wasn't (e.g.,
 # dbuild sets it), let's try some common possibilities
-if [ -z "$JAVA8_HOME"]; then
+if [ -z "$JAVA8_HOME" ]; then
     for i in /usr/lib/jvm/java-1.8.0
     do
         if [ -e "$i" ]; then


### PR DESCRIPTION
next build stage is failing with the following error:
```
23:41:53  [760/2763] cd tools/java && ./reloc/build_reloc.sh --version $(<../../build/SCYLLA-PRODUCT-FILE)-$(<../../build/SCYLLA-VERSION-FILE)-$(<../../build/SCYLLA-RELEASE-FILE) --nodeps
23:41:53  ./reloc/build_reloc.sh: line 70: [: missing `]'
```

looks like there's a missing space before the closing bracket (related to changes done in https://github.com/scylladb/scylla-tools-java/commit/a2fe67fd425b29d83f0b9737ea8fa6f6ca095d15)

Fixing