### PR TITLE
removeNode: support ignoreNodes options

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -4395,6 +4395,14 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         removingNode = null;
     }
 
+    public void removeNode(String hostIdString, String ignoreNodes)
+    {
+        if (ignoreNodes != null)
+            throw new UnsupportedOperationException("ignoreNodes is not supported.");
+
+        removeNode(hostIdString);
+    }
+
     public void confirmReplication(InetAddress node)
     {
         // replicatingNodes can be empty in the case where this node used to be a removal coordinator,

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -402,6 +402,8 @@ public interface StorageServiceMBean extends NotificationEmitter
      */
     public void removeNode(String token);
 
+    public void removeNode(String token, String ignoreNodes);
+
     /**
      * Get the status of a token removal.
      */

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -765,9 +765,9 @@ public class NodeProbe implements AutoCloseable
         ssProxy.move(newToken);
     }
 
-    public void removeNode(String token)
+    public void removeNode(String token, String ignoreNodes)
     {
-        ssProxy.removeNode(token);
+        ssProxy.removeNode(token, ignoreNodes);
     }
 
     public String getRemovalStatus()

--- a/src/java/org/apache/cassandra/tools/nodetool/RemoveNode.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/RemoveNode.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.tools.nodetool;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import io.airlift.command.Arguments;
 import io.airlift.command.Command;
+import io.airlift.command.Option;
 
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
@@ -29,6 +30,9 @@ public class RemoveNode extends NodeToolCmd
 {
     @Arguments(title = "remove_operation", usage = "<status>|<force>|<ID>", description = "Show status of current node removal, force completion of pending removal, or remove provided ID", required = true)
     private String removeOperation = EMPTY;
+
+    @Option(title = "ignore_dead_nodes", name = {"-ignore", "--ignore-nodes", "--ignore-dead-nodes"}, description = "Use -ignore to specify a comma-separated list of dead nodes to ignore during removenode")
+    private String ignoreNodes = null;
 
     @Override
     public void execute(NodeProbe probe)
@@ -43,7 +47,7 @@ public class RemoveNode extends NodeToolCmd
                 probe.forceRemoveCompletion();
                 break;
             default:
-                probe.removeNode(removeOperation);
+                probe.removeNode(removeOperation, ignoreNodes);
                 break;
         }
     }


### PR DESCRIPTION
Fixes #225

DTest:
```
DTEST_REQUIRE=disabled CASSANDRA_DIR=../scylla/build/dev NOSE_PROCESSES=2 ./scripts/run_test.sh update_cluster_layout_tests.py:TestUpdateClusterLayout.{simple_removenode_1_test,simple_removenode_2_test,simple_removenode_3_test,simple_remove_2_nodes_3_test,simple_removenode_3_nodetool_test,simple_remove_2_nodes_3_nodetool_test,simple_removenode_4_test,simple_removenode_5_test}
```

Signed-off-by: Benny Halevy <bhalevy@scylladb.com>