### PR TITLE
dist: remove unneeded dependency to PyYAML

### DIFF
--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -17,7 +17,7 @@ Description: Scylla database tools
 
 Package: %{product}-tools-core
 Architecture: all
-Depends: openjdk-8-jre-headless | openjdk-8-jre | oracle-java8-set-default | adoptopenjdk-8-hotspot-jre | openjdk-11-jre-headless | openjdk-11-jre | oracle-java11-set-default, python (>= 2.7), python-yaml, procps
+Depends: openjdk-8-jre-headless | openjdk-8-jre | oracle-java8-set-default | adoptopenjdk-8-hotspot-jre | openjdk-11-jre-headless | openjdk-11-jre | oracle-java11-set-default, python (>= 2.7), procps
 Description: Scylla database tools core files
  Core files for scylla database tools
 Replaces: %{product}-tools (<< 2.0~rc0)

--- a/dist/redhat/scylla-tools.spec
+++ b/dist/redhat/scylla-tools.spec
@@ -23,10 +23,6 @@ Summary:        Core files for Scylla tools
 Version:        %{version}
 Release:        %{release}%{?dist}
 Requires:       jre-1.8.0-headless python2
-# Since RHEL7 and RHEL8 has different pacakge name for pyyaml,
-# we need to use a file path to the resolve package name on
-# current distribution.
-Requires:       /usr/lib64/python2.7/site-packages/yaml/__init__.py
 
 %global __brp_python_bytecompile %{nil}
 %global __brp_mangle_shebangs %{nil}


### PR DESCRIPTION
We added dependency to PyYAML at 6f4b9c2, it was for filter_cassandra_attributes.py.
However, we removed the script at 3eca0e3, but we never update package dependency.

Since we have installation problem with this package, we should drop this (scylladb/scylla#9498, scylladb/scylla#9045).

Fixes #279