### PR TITLE
dist/debian: replace "python (>=2.7)" with "python2"

### DIFF
--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -17,7 +17,7 @@ Description: Scylla database tools
 
 Package: %{product}-tools-core
 Architecture: all
-Depends: openjdk-8-jre-headless | openjdk-8-jre | oracle-java8-set-default | adoptopenjdk-8-hotspot-jre | openjdk-11-jre-headless | openjdk-11-jre | oracle-java11-set-default, python (>= 2.7), procps
+Depends: openjdk-8-jre-headless | openjdk-8-jre | oracle-java8-set-default | adoptopenjdk-8-hotspot-jre | openjdk-11-jre-headless | openjdk-11-jre | oracle-java11-set-default, python2, procps
 Description: Scylla database tools core files
  Core files for scylla database tools
 Replaces: %{product}-tools (<< 2.0~rc0)


### PR DESCRIPTION
From Debian 12 and Ubuntu 22.04, we cannot depends to "python" virtual package,
we need to specify "python2" instead.

See scylladb/scylla#9498