### PR TITLE
Fix typo in `cassandra-stress` output

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/util/JavaDriverClient.java
+++ b/tools/stress/src/org/apache/cassandra/stress/util/JavaDriverClient.java
@@ -166,7 +166,7 @@ public class JavaDriverClient
                 connectionsPerHost);
         for (Host host : metadata.getAllHosts())
         {
-            System.out.printf("Datatacenter: %s; Host: %s; Rack: %s%n",
+            System.out.printf("Datacenter: %s; Host: %s; Rack: %s%n",
                     host.getDatacenter(), host.getAddress(), host.getRack());
         }
 


### PR DESCRIPTION
I believe "Datatacenter" in the output should be "Datacenter".