### PR TITLE
dist/debian:set either python (>=2.7) or python2

### DIFF
--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -17,7 +17,7 @@ Description: Scylla database tools
 
 Package: %{product}-tools-core
 Architecture: all
-Depends: openjdk-8-jre-headless | openjdk-8-jre | oracle-java8-set-default | adoptopenjdk-8-hotspot-jre | openjdk-11-jre-headless | openjdk-11-jre | oracle-java11-set-default, python2, procps
+Depends: openjdk-8-jre-headless | openjdk-8-jre | oracle-java8-set-default | adoptopenjdk-8-hotspot-jre | openjdk-11-jre-headless | openjdk-11-jre | oracle-java11-set-default, python (>=2.7) | python2, procps
 Description: Scylla database tools core files
  Core files for scylla database tools
 Replaces: %{product}-tools (<< 2.0~rc0)


### PR DESCRIPTION
The changes we did in https://github.com/scylladb/scylla-tools-java/commit/6249bfbe2ff9f4be5ddc6cd3af6f191a636784eb breaks scylla installation in debian9, ubuntu16.04 and ubuntu18.04

Fixes: scylladb/scylla#9886