### PR TITLE
removeNode: Remove other alias for --ignore-dead-nodes

### DIFF
--- a/src/java/org/apache/cassandra/tools/nodetool/RemoveNode.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/RemoveNode.java
@@ -31,7 +31,7 @@ public class RemoveNode extends NodeToolCmd
     @Arguments(title = "remove_operation", usage = "<status>|<force>|<ID>", description = "Show status of current node removal, force completion of pending removal, or remove provided ID", required = true)
     private String removeOperation = EMPTY;
 
-    @Option(title = "ignore_dead_nodes", name = {"-ignore", "--ignore-nodes", "--ignore-dead-nodes"}, description = "Use -ignore to specify a comma-separated list of dead nodes to ignore during removenode")
+    @Option(title = "ignore_dead_nodes", name = {"--ignore-dead-nodes"}, description = "Use --ignore-dead-nodes to specify a comma-separated list of dead nodes to ignore during removenode")
     private String ignoreNodes = null;
 
     @Override


### PR DESCRIPTION
It is better to have a single option --ignore-dead-nodes for this, not
-ignore and --ignore-nodes. We want to stress that we are ignoring dead
nodes, not any other nodes in the cluster. We need to use this option
very careful, so short alias does not make much sense. The more options,
the more to document and more possible confusion.