### PR TITLE
CASSANDRA-17581 fix NodeProbe: Malformed IPv6 address at index

### DIFF
--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -107,7 +107,7 @@ import org.apache.cassandra.tools.nodetool.GetTimeout;
  */
 public class NodeProbe implements AutoCloseable
 {
-    private static final String fmtUrl = "service:jmx:rmi:///jndi/rmi://[%s]:%d/jmxrmi";
+    private static final String fmtUrl = "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi";
     private static final String ssObjName = "org.apache.cassandra.db:type=StorageService";
     private static final int defaultPort = 7199;
     final String host;


### PR DESCRIPTION
Fix error when new NodeProbe("127.0.0.1", 7199) with jdk 1.8.0_332:

```
java.io.IOException: Failed to retrieve RMIServer stub:
 javax.naming.InvalidNameException: Malformed IPv6 address at index 7: rmi://[127.0.0.1]:7199
 Root exception is java.lang.IllegalArgumentException: Malformed IPv6 address at index 7: rmi://[127.0.0.1]:7199
```

Ref: https://github.com/apache/cassandra/pull/1586
Ref: https://issues.apache.org/jira/projects/CASSANDRA/issues/CASSANDRA-17581
Ref: https://www.oracle.com/java/technologies/javase/8u331-relnotes.html#JDK-8278972
Ref: https://community.datastax.com/questions/13764/java-version-for-cassandra-3113.html