### PR TITLE
Add Scylla-specific table options to Option enum

### DIFF
--- a/src/java/org/apache/cassandra/schema/TableParams.java
+++ b/src/java/org/apache/cassandra/schema/TableParams.java
@@ -51,7 +51,12 @@ public final class TableParams
         READ_REPAIR_CHANCE,
         SPECULATIVE_RETRY,
         CRC_CHECK_CHANCE,
-        CDC;
+        CDC,
+
+        // Scylla specific table options.
+        // It is used indirectly in BulkLoader validation.
+        SCYLLA_TAGS,
+        SCYLLA_ENCRYPTION_OPTIONS;
 
         @Override
         public String toString()


### PR DESCRIPTION
Add Scylla-specific table options (`scylla_tags`, `scylla_encryption_options`) to the `Option` enum in `TableParams` class.

This enum is used indirectly in `BulkLoader` (`sstableloader`) when validating whether table parameters are correct. When `scylla_tags` was missing from that enum, importing Alternator SSTables would fail as `scylla_tags` was an unknown table option (issue scylladb/scylla#10856).

Similar changes were already done in cqlshlib: f408ce81ba0da8594b72d71d3cf3591e23096d8e and 1592aa20fb41fed607ac48fd6ac1038f4bb6c665.

Fixes scylladb/scylla#10856.