### PR TITLE
scylla-tools-java: Update "six" library used by cqlsh/python driver

### DIFF
--- a/.build/build-resolver.xml
+++ b/.build/build-resolver.xml
@@ -179,7 +179,7 @@
 
         <!-- files.pythonhosted.org -->
         <get src="https://files.pythonhosted.org/packages/59/a0/cf4cd997e1750f0c2d91c6ea5abea218251c43c3581bcc2f118b00baf5cf/futures-2.1.6-py2.py3-none-any.whl" dest="${local.repository}/org/apache/cassandra/deps/futures-2.1.6-py2.py3-none-any.zip" usetimestamp="true" quiet="true" skipexisting="true"/>
-        <get src="https://files.pythonhosted.org/packages/2e/a4/6dcb84af409b7bc0c258a0d6bd7e14231724d9a46b750c048f09d74d870c/six-1.7.3-py2.py3-none-any.whl" dest="${local.repository}/org/apache/cassandra/deps/six-1.7.3-py2.py3-none-any.zip" usetimestamp="true" quiet="true" skipexisting="true"/>
+        <get src="https://files.pythonhosted.org/packages/73/fb/00a976f728d0d1fecfe898238ce23f502a721c0ac0ecfedb80e0d88c64e9/six-1.12.0-py2.py3-none-any.whl" dest="${local.repository}/org/apache/cassandra/deps/six-1.12.0-py2.py3-none-any.zip" usetimestamp="true" quiet="true" skipexisting="true"/>
 
         <!-- python-driver -->
         <get src="https://raw.githubusercontent.com/apache/cassandra/${lib.download.sha}/lib/cassandra-driver-internal-only-3.11.0-bb96859b.zip" dest="${local.repository}/org/apache/cassandra/deps/cassandra-driver-internal-only-3.11.0-bb96859b.zip" usetimestamp="true" quiet="true" skipexisting="true"/>


### PR DESCRIPTION
commit https://github.com/scylladb/scylla-tools-java/commit/2fdf1d27620fe2bce2a3c5989beab40b05fda1e6 from upstream
remove the usage of libraries in ./lib, and fetching them using
`build-resolver.xml`

commit https://github.com/scylladb/scylla-tools-java/commit/8335869e2de98c7167f81a66cef734914e1ec3e4 downloaded newer
version of six to `./lib`, but now need to update the `build-resolver.xml`
with the correct version we need

Fixes: https://github.com/scylladb/scylla-tools-java/issues/87