### PR TITLE
dist/debian: drop upgrading from scylla-tools < 2.0

### DIFF
--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -8,7 +8,7 @@ Rules-Requires-Root: no
 
 Package: %{product}-tools
 Architecture: all
-Depends: %{product}-conf, %{product}-tools-core (>= 2.0~rc0), ${misc:Depends}
+Depends: %{product}-conf, %{product}-tools-core, ${misc:Depends}
 Recommends: ntp | time-daemon
 Conflicts: cassandra
 Description: Scylla database tools
@@ -20,5 +20,3 @@ Architecture: all
 Depends: openjdk-8-jre-headless | openjdk-8-jre | oracle-java8-set-default | adoptopenjdk-8-hotspot-jre | openjdk-11-jre-headless | openjdk-11-jre | oracle-java11-set-default, python (>=2.7) | python2, procps
 Description: Scylla database tools core files
  Core files for scylla database tools
-Replaces: %{product}-tools (<< 2.0~rc0)
-Breaks: %{product}-tools (<< 2.0~rc0)


### PR DESCRIPTION
We have added following conditions on debian/control when we splited
scylla-tools package into scylla-tools and scylla-tools-core:

Package: scylla-tools
Depends: scylla-tools-core (>= 2.0~rc0)

Package: scylla-tools-core
Replaces: scylla-tools (<< 2.0~rc0)
Breaks: scylla-tools (<< 2.0~rc0)

But Scylla < 2.0 is too old, we don't need to support upgrading from
this version anymore, so we can just drop these conditions.

Related: scylladb/scylla-enterprise-tools-java#31