### PR TITLE
dist/debian:add python3 as dependency

### DIFF
--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -17,6 +17,6 @@ Description: Scylla database tools
 
 Package: %{product}-tools-core
 Architecture: all
-Depends: openjdk-8-jre-headless | openjdk-8-jre | oracle-java8-set-default | adoptopenjdk-8-hotspot-jre | openjdk-11-jre-headless | openjdk-11-jre | oracle-java11-set-default, python (>=2.7) | python2, procps
+Depends: openjdk-8-jre-headless | openjdk-8-jre | oracle-java8-set-default | adoptopenjdk-8-hotspot-jre | openjdk-11-jre-headless | openjdk-11-jre | oracle-java11-set-default, python (>=2.7) | python2 | python3, procps
 Description: Scylla database tools core files
  Core files for scylla database tools


### PR DESCRIPTION
In https://github.com/scylladb/scylladb/pull/11440 we will start building Scylla docker images based on Ubuntu:22.04, adding `python3` as a dependency since `python` package is not available anymore