### PR TITLE
install.sh is using wrong permissions for install cqlsh files

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -122,7 +122,7 @@ fi
 install -d -m755 "$rprefix"/share/cassandra/pylib
 install -d -m755 "$retc"/bash_completion.d
 install -m644 dist/common/nodetool-completion "$retc"/bash_completion.d
-cp -r pylib/cqlshlib "$rprefix"/share/cassandra/pylib
+cp -rp pylib/cqlshlib "$rprefix"/share/cassandra/pylib
 for i in bin/{nodetool,sstableloader,cqlsh,cqlsh.py,scylla-sstableloader} tools/bin/{cassandra-stress,cassandra-stressd,sstabledump,sstablelevelreset,sstablemetadata,sstablerepairedset}; do
     bn=$(basename $i)
     install -m755 $i "$rprefix"/share/cassandra/bin


### PR DESCRIPTION
`install.sh` is using copy, and not install
```
cp -r pylib/cqlshlib "$rprefix"/share/cassandra/pylib
```

on oel81 when installing unified relocatable package, cqlsh is failing to run from a user which isn't root (when root did the install)
```
07:45:21  Command: 'cqlsh --no-color   --request-timeout=120 --connect-timeout=60  -e "desc keyspaces" 10.4.2.93 9042'
07:45:21  Exit code: 1
07:45:21  Stdout:
07:45:21  Stderr:
07:45:21  /etc/bashrc: line 99: TMOUT: readonly variable
07:45:21  /etc/bashrc: line 100: TMOUT: readonly variable
07:45:21  Traceback (most recent call last):
07:45:21  File "/opt/scylladb/share/cassandra/bin/cqlsh.py", line 169, in <module>
07:45:21  from cqlshlib import cql3handling, cqlhandling, pylexotron, sslhandling, cqlshhandling
07:45:21  ImportError: No module named cqlshlib
```
reported by @fruch 

Closes: https://github.com/scylladb/scylla-tools-java/issues/310