### PR TITLE
Fix `cassandra-stress -log hdrfile=...` with java 11

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -374,6 +374,7 @@
         <license name="The Apache Software License, Version 2.0" url="https://www.apache.org/licenses/LICENSE-2.0.txt"/>
         <scm connection="${scm.connection}" developerConnection="${scm.developerConnection}" url="${scm.url}"/>
         <dependencyManagement>
+          <dependency groupId="javax.xml.bind" artifactId="jaxb-api" version="2.3.0"/>
           <dependency groupId="org.xerial.snappy" artifactId="snappy-java" version="1.1.1.7"/>
           <dependency groupId="net.jpountz.lz4" artifactId="lz4" version="1.3.0"/>
           <dependency groupId="com.ning" artifactId="compress-lzf" version="0.8.4"/>
@@ -634,6 +635,7 @@
                 version="${version}"
                 relativePath="${final.name}-parent.pom"/>
         <scm connection="${scm.connection}" developerConnection="${scm.developerConnection}" url="${scm.url}"/>
+        <dependency groupId="javax.xml.bind" artifactId="jaxb-api"/>
         <dependency groupId="org.xerial.snappy" artifactId="snappy-java"/>
         <dependency groupId="net.jpountz.lz4" artifactId="lz4"/>
         <dependency groupId="com.ning" artifactId="compress-lzf"/>


### PR DESCRIPTION
Since Java 9, javax/xml/bind/DatatypeConverter is no longer available by default, and has to be added as an explicit dependency.

Fixes #308