### PR TITLE
cassandra-stress: pass all hosts straight to the driver

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/settings/StressSettings.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/StressSettings.java
@@ -205,12 +205,11 @@ public class StressSettings implements Serializable
 
             try
             {
-                String currentNode = node.randomNode();
                 if (client != null)
                     return client;
 
                 EncryptionOptions.ClientEncryptionOptions encOptions = transport.getEncryptionOptions();
-                JavaDriverClient c = new JavaDriverClient(this, currentNode, port.nativePort, encOptions);
+                JavaDriverClient c = new JavaDriverClient(this, node.nodes, port.nativePort, encOptions);
                 c.connect(mode.compression());
                 if (setKeyspace)
                     c.execute("USE \"" + schema.keyspace + "\";", org.apache.cassandra.db.ConsistencyLevel.ONE);

--- a/tools/stress/src/org/apache/cassandra/stress/util/JavaDriverClient.java
+++ b/tools/stress/src/org/apache/cassandra/stress/util/JavaDriverClient.java
@@ -42,7 +42,7 @@ public class JavaDriverClient
         InternalLoggerFactory.setDefaultFactory(new Slf4JLoggerFactory());
     }
 
-    public final String host;
+    public final List<String> hosts;
     public final int port;
     public final String username;
     public final String password;
@@ -60,15 +60,15 @@ public class JavaDriverClient
 
     private static final ConcurrentMap<String, PreparedStatement> stmts = new ConcurrentHashMap<>();
 
-    public JavaDriverClient(StressSettings settings, String host, int port)
+    public JavaDriverClient(StressSettings settings, List<String> hosts, int port)
     {
-        this(settings, host, port, new EncryptionOptions.ClientEncryptionOptions());
+        this(settings, hosts, port, new EncryptionOptions.ClientEncryptionOptions());
     }
 
-    public JavaDriverClient(StressSettings settings, String host, int port, EncryptionOptions.ClientEncryptionOptions encryptionOptions)
+    public JavaDriverClient(StressSettings settings, List<String> hosts, int port, EncryptionOptions.ClientEncryptionOptions encryptionOptions)
     {
         this.protocolVersion = settings.mode.protocolVersion;
-        this.host = host;
+        this.hosts = hosts;
         this.port = port;
         this.username = settings.mode.username;
         this.password = settings.mode.password;
@@ -138,7 +138,7 @@ public class JavaDriverClient
 
         if (this.cloudConfigFile == null)
         {
-            clusterBuilder.addContactPoint(host);
+            clusterBuilder.addContactPoints(hosts.toArray(new String[0]));
         }
 
         clusterBuilder.withPort(port)


### PR DESCRIPTION
In cases of multiple contact points configued from commandline code was randomly selecting one host and pass that to the cql driver if for some reason that specfic node wasn't available the whole command would fail.

removing this random, and passing all hosts to the driver fix this issue, and the driver code is more then capble of handling a situation of some contact points unreachable