### PR TITLE
Mark "system_distributed_everywhere" as system keyspace

### DIFF
--- a/pylib/cqlshlib/cql3handling.py
+++ b/pylib/cqlshlib/cql3handling.py
@@ -35,7 +35,7 @@ class UnexpectedTableStructure(UserWarning):
         return 'Unexpected table structure; may not translate correctly to CQL. ' + self.msg
 
 
-SYSTEM_KEYSPACES = ('system', 'system_schema', 'system_traces', 'system_auth', 'system_distributed')
+SYSTEM_KEYSPACES = ('system', 'system_schema', 'system_traces', 'system_auth', 'system_distributed', 'system_distributed_everywhere')
 NONALTERBALE_KEYSPACES = ('system', 'system_schema')
 
 


### PR DESCRIPTION
Add `system_distributed_everywhere` keyspace to `SYSTEM_KEYSPACES` list, which marks which keyspaces are recognized as system keyspaces.

This controls for example which keyspaces are not shown when executing `DESC SCHEMA` command in cqlsh. Before this change, `DESC SCHEMA` would print the schema of `system_distributed_everywhere`, which was incorrect as `DESC SCHEMA` is supposed to print only user tables.

Fixes scylladb/scylla-tools-java#318