### PR TITLE
Update Java Driver version to 3.11.2.4

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -463,7 +463,7 @@
           <dependency groupId="com.clearspring.analytics" artifactId="stream" version="2.5.2">
             <exclusion groupId="it.unimi.dsi" artifactId="fastutil" />
           </dependency>
-          <dependency groupId="com.scylladb" artifactId="scylla-driver-core" version="3.11.2.1" classifier="shaded" />
+          <dependency groupId="com.scylladb" artifactId="scylla-driver-core" version="3.11.2.4" classifier="shaded" />
 	  <!-- UPDATE AND UNCOMMENT ON THE DRIVER RELEASE, BEFORE 4.0 RELEASE
           <dependency groupId="com.datastax.cassandra" artifactId="cassandra-driver-core" version="3.0.1" classifier="shaded">
             <exclusion groupId="io.netty" artifactId="netty-buffer"/>


### PR DESCRIPTION
Update the version of Java Driver from 3.11.2.1 to 3.11.2.4. The  differences between the versions are fixes to serverless support:
1. Driver connecting to address in "Server" field of the bundle instead  of "NodeDomain" (https://github.com/scylladb/java-driver/pull/173)
2. Moving parsing of "insecureSkipTlsVerify" from "AuthInfo" field in serverless bundle file to "Datacenter" fields (https://github.com/scylladb/java-driver/pull/177)

Without this change, cassandra-stress could not connect correctly to a local serverless cluster created with Scylla Operator or CCM (see https://github.com/scylladb/java-driver/issues/164).

Tested manually end-to-end scenario: starting serverless Scylla with CCM and using cassandra-stress to write to it:
```
mkdir /tmp/ccm-with-tools-java
ccm create ccm_with_tools_java -i 127.0.1. -n 1 --scylla -v release:5.0.0 --config-dir=/tmp/ccm-with-tools-java
ccm start  --sni-proxy --sni-port 7777 --config-dir=/tmp/ccm-with-tools-java
./tools/bin/cassandra-stress write -cloudconf "file=/tmp/ccm-with-tools-java/ccm_with_tools_java/config_data.yaml"
```