### PR TITLE
Fix cassandra-stress -log hdrfile=... with java 11

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -372,7 +372,7 @@
             <exclusion groupId="com.google.errorprone" artifactId="error_prone_annotations" />
           </dependency>
           <dependency groupId="com.github.luben" artifactId="zstd-jni" version="1.3.8-5"/>
-          <dependency groupId="org.hdrhistogram" artifactId="HdrHistogram" version="2.1.9"/>
+          <dependency groupId="org.hdrhistogram" artifactId="HdrHistogram" version="2.1.12"/>
           <dependency groupId="commons-cli" artifactId="commons-cli" version="1.1"/>
           <dependency groupId="commons-codec" artifactId="commons-codec" version="1.9"/>
           <dependency groupId="commons-io" artifactId="commons-io" version="2.6" scope="test"/>


### PR DESCRIPTION
Since Java 9, javax/xml/bind/DatatypeConverter is no longer available by default, and has to be added as an explicit dependency. This causes the current version of HdrHistogram in cassandra-stress to fail with Java >9.

To fix that, we upgrade HdrHistogram to its current version, which does not have the javax dependency.

Fixes #308