### PR TITLE
nodetool: add `--primary-replica-only` option to `refresh`

### DIFF
--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -5302,7 +5302,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
     /**
      * #{@inheritDoc}
      */
-    public void loadNewSSTables(String ksName, String cfName, boolean isLoadAndStream)
+    public void loadNewSSTables(String ksName, String cfName, boolean isLoadAndStream, boolean isPrimaryReplicaOnly)
     {
         if (!isInitialized())
             throw new RuntimeException("Not yet initialized, can't load new sstables");

--- a/src/java/org/apache/cassandra/service/StorageServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/StorageServiceMBean.java
@@ -640,8 +640,9 @@ public interface StorageServiceMBean extends NotificationEmitter
      * @param ksName The parent keyspace name
      * @param tableName The ColumnFamily name where SSTables belong
      * @param isLoadAndStream Whether or not arbitrary SSTables should be loaded (and streamed to the owning nodes)
+     * @param isPrimaryReplicaOnly Load the sstables and stream to primary replica node that owns the data.
      */
-    public void loadNewSSTables(String ksName, String tableName, boolean isLoadAndStream);
+    public void loadNewSSTables(String ksName, String tableName, boolean isLoadAndStream, boolean isPrimaryReplicaOnly);
 
     /**
      * Return a List of Tokens representing a sample of keys across all ColumnFamilyStores.

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -1248,9 +1248,9 @@ public class NodeProbe implements AutoCloseable
         return msProxy.getDroppedMessages();
     }
 
-    public void loadNewSSTables(String ksName, String cfName, boolean isLoadAndStream)
+    public void loadNewSSTables(String ksName, String cfName, boolean isLoadAndStream, boolean isPrimaryReplicaOnly)
     {
-        ssProxy.loadNewSSTables(ksName, cfName, isLoadAndStream);
+        ssProxy.loadNewSSTables(ksName, cfName, isLoadAndStream, isPrimaryReplicaOnly);
     }
 
     public void rebuildIndex(String ksName, String cfName, String... idxNames)

--- a/src/java/org/apache/cassandra/tools/nodetool/Refresh.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Refresh.java
@@ -39,10 +39,15 @@ public class Refresh extends NodeToolCmd
     description = "Allows loading sstables that do not belong to this node, in which case they are automatically streamed to the owning nodes.")
     private boolean isLoadAndStream = false;
 
+    @Option(title = "primary-replica-only",
+    name = {"-pro", "--primary-replica-only"},
+    description = "Load the sstables and stream to primary replica node that owns the data. Repair is needed after the load and stream process.")
+    private boolean isPrimaryReplicaOnly= false;
+
     @Override
     public void execute(NodeProbe probe)
     {
         checkArgument(args.size() == 2, "refresh requires ks and cf args");
-        probe.loadNewSSTables(args.get(0), args.get(1), isLoadAndStream);
+        probe.loadNewSSTables(args.get(0), args.get(1), isLoadAndStream, isPrimaryReplicaOnly);
     }
 }


### PR DESCRIPTION
This information is forwarded through JMX to Scylla, adding an extra {"primary_replica_only", "true"} entry in the POST request to Scylla's HTTP API at `storage_service/sstables/{keyspace}` endpoint.

More about this feature: scylladb/scylla#7846

This is a follow up of commit 3b378f7095e3cd8b776fd188a68234431dfe4d70.

$ nodetool refresh -las -pro ks2 standard1
Loading new SSTables for keyspace=ks2, table=standard1, load_and_stream=true, primary_replica_only=true

$ nodetool refresh -las ks2 standard1
Loading new SSTables for keyspace=ks2, table=standard1, load_and_stream=true, primary_replica_only=false

$ nodetool refresh ks2 standard1
Loading new SSTables for keyspace=ks2, table=standard1, load_and_stream=false, primary_replica_only=false

Fixes #282