### PR TITLE
README.md: drop cqlsh from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Scylla tools
 
-This repository contains `cqlsh`, `nodetool`, and other Apache Cassandra compatible tools for Scylla.
+This repository contains `nodetool` and other Apache Cassandra compatible tools for Scylla.
 
 Please refer to the [Scylla git repository](https://github.com/scylladb/scylla) for more information how to build and run the tools.


### PR DESCRIPTION
cqlsh was removed from scylla-tools-java in
eddef02301726211e9968b75eeb625cb2a545009. so let's drop it from `README.md`.