### PR TITLE
Use EstimatedHistogram in metricPercentilesAsArray(JmxHistogramMBean)

### DIFF
--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -101,6 +101,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.cassandra.tools.nodetool.GetTimeout;
+import org.apache.cassandra.utils.EstimatedHistogram;
 
 /**
  * JMX client operations for Cassandra.
@@ -1594,15 +1595,15 @@ public class NodeProbe implements AutoCloseable
 
     public double[] metricPercentilesAsArray(CassandraMetricsRegistry.JmxHistogramMBean metric)
     {
-        BufferSamples bs = new BufferSamples(metric.values());
+        EstimatedHistogram eh = new EstimatedHistogram(metric.values());
 
-        return new double[]{ bs.getValue(0.5),
-                bs.getValue(0.75),
-                bs.getValue(0.95),
-                bs.getValue(0.98),
-                bs.getValue(0.99),
-                bs.getMin(),
-                bs.getMax()};
+        return new double[]{ eh.percentile(0.5),
+                eh.percentile(0.75),
+                eh.percentile(0.95),
+                eh.percentile(0.98),
+                eh.percentile(0.99),
+                eh.min(),
+                eh.max()};
     }
 
     public double[] metricPercentilesAsArray(CassandraMetricsRegistry.JmxTimerMBean metric)


### PR DESCRIPTION
NodeProbe::metricPercentilesAsArray(JmxHistogramMBean) is expected
to return an array with percentiles obtained from a given histogram.
Currently BufferSamples object is created out of the original jmx
histogram's values and its getValue method is used to create an array.
BufferSamples::getValue(double) expects data in different format than
the provided one, though.

EstimatedHistogram, which is compactible with original histogram,
is created out of metric values.

Fixes: #330.