### PR TITLE
s/egrep/grep -E/

### DIFF
--- a/conf/cassandra-env.sh
+++ b/conf/cassandra-env.sh
@@ -19,7 +19,7 @@ calculate_heap_sizes()
     case "`uname`" in
         Linux)
             system_memory_in_mb=`free -m | awk '/:/ {print $2;exit}'`
-            system_cpu_cores=`egrep -c 'processor([[:space:]]+):.*' /proc/cpuinfo`
+            system_cpu_cores=`grep -E -c 'processor([[:space:]]+):.*' /proc/cpuinfo`
         ;;
         FreeBSD)
             system_memory_in_bytes=`sysctl hw.physmem | awk '{print $2}'`

--- a/dist/common/nodetool-completion
+++ b/dist/common/nodetool-completion
@@ -9,7 +9,7 @@ have nodetool && have cqlsh &&
 
     get_keyspaces()
     {
-        [ -z "$keyspaces" ] && keyspaces=$(echo "DESCRIBE KEYSPACES" | cqlsh | egrep -v '^$')
+        [ -z "$keyspaces" ] && keyspaces=$(echo "DESCRIBE KEYSPACES" | cqlsh | grep -E -v '^$')
         echo $keyspaces
     }
 
@@ -33,7 +33,7 @@ have nodetool && have cqlsh &&
     {
         local prev
         prev=$1
-        [ -z "${cf[$prev]}" ] && cf[$prev]=$(echo "DESCRIBE COLUMNFAMILIES" | cqlsh -k ${prev} | egrep -v '^$')
+        [ -z "${cf[$prev]}" ] && cf[$prev]=$(echo "DESCRIBE COLUMNFAMILIES" | cqlsh -k ${prev} | grep -E -v '^$')
         echo ${cf[$prev]}
     }
 
@@ -193,7 +193,7 @@ have nodetool && have cqlsh &&
 
         if [[ $COMP_CWORD -eq 1 ]] ; then
             COMPREPLY=( $(compgen -W "${lngopt} ${shopt}" -- "${cur}") )
-        elif [[ $(echo "${lngopt}"|egrep -c "\b${prev}\b") -gt 0 ]] ; then
+        elif [[ $(echo "${lngopt}"|grep -E -c "\b${prev}\b") -gt 0 ]] ; then
             if echo $optwks|grep -q "\b$prev\b" ; then
                 show_keyspaces "${cur}"
             else


### PR DESCRIPTION
GNU Grep 3.8 started to emit warning like:
```
egrep: warning: egrep is obsolescent; using grep -E
```

when one runs it with `egrep`. see also its release notes: https://lists.gnu.org/archive/html/info-gnu/2022-09/msg00001.html

to silence this warning, let's just follow the
suggestion and call it with the `-E` command line option.