### PR TITLE
cassandra-stress: add support for using RackAwareRoundRobinPolicy

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -463,7 +463,7 @@
           <dependency groupId="com.clearspring.analytics" artifactId="stream" version="2.5.2">
             <exclusion groupId="it.unimi.dsi" artifactId="fastutil" />
           </dependency>
-          <dependency groupId="com.scylladb" artifactId="scylla-driver-core" version="3.11.2.4" classifier="shaded" />
+          <dependency groupId="com.scylladb" artifactId="scylla-driver-core" version="3.11.2.5" classifier="shaded" />
 	  <!-- UPDATE AND UNCOMMENT ON THE DRIVER RELEASE, BEFORE 4.0 RELEASE
           <dependency groupId="com.datastax.cassandra" artifactId="cassandra-driver-core" version="3.0.1" classifier="shaded">
             <exclusion groupId="io.netty" artifactId="netty-buffer"/>

--- a/tools/stress/src/org/apache/cassandra/stress/settings/SettingsNode.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/SettingsNode.java
@@ -35,6 +35,7 @@ public class SettingsNode implements Serializable
     public final List<String> nodes;
     public final boolean isWhiteList;
     public final String datacenter;
+    public final String rack;
 
     public SettingsNode(Options options)
     {
@@ -67,6 +68,7 @@ public class SettingsNode implements Serializable
 
         isWhiteList = options.whitelist.setByUser();
         datacenter = options.datacenter.value();
+        rack = options.rack.value();
     }
 
     public Set<String> resolveAllPermitted(StressSettings settings)
@@ -137,6 +139,7 @@ public class SettingsNode implements Serializable
     public static final class Options extends GroupedOptions
     {
         final OptionSimple datacenter = new OptionSimple("datacenter=", ".*", null, "Datacenter used for DCAwareRoundRobinLoadPolicy", false);
+        final OptionSimple rack = new OptionSimple("rack=", ".*", null, "Rack used for RackAwareRoundRobinLoadPolicy", false); 
         final OptionSimple whitelist = new OptionSimple("whitelist", "", null, "Limit communications to the provided nodes", false);
         final OptionSimple file = new OptionSimple("file=", ".*", null, "Node file (one per line)", false);
         final OptionSimple list = new OptionSimple("", "[^=,]+(,[^=,]+)*", "localhost", "comma delimited list of nodes", false);
@@ -144,7 +147,7 @@ public class SettingsNode implements Serializable
         @Override
         public List<? extends Option> options()
         {
-            return Arrays.asList(datacenter, whitelist, file, list);
+            return Arrays.asList(datacenter, rack, whitelist, file, list);
         }
     }
 
@@ -154,6 +157,7 @@ public class SettingsNode implements Serializable
         out.println("  Nodes: " + nodes);
         out.println("  Is White List: " + isWhiteList);
         out.println("  Datacenter: " + datacenter);
+        out.println("  Rack: " + rack);
     }
 
     public static SettingsNode get(Map<String, String[]> clArgs)

--- a/tools/stress/src/org/apache/cassandra/stress/util/JavaDriverClient.java
+++ b/tools/stress/src/org/apache/cassandra/stress/util/JavaDriverClient.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ConcurrentMap;
 import javax.net.ssl.SSLContext;
 
 import com.datastax.driver.core.*;
-import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
+import com.datastax.driver.core.policies.RackAwareRoundRobinPolicy;
 import com.datastax.driver.core.policies.LoadBalancingPolicy;
 import com.datastax.driver.core.policies.TokenAwarePolicy;
 import com.datastax.driver.core.policies.WhiteListPolicy;
@@ -93,9 +93,12 @@ public class JavaDriverClient
 
     private LoadBalancingPolicy loadBalancingPolicy(StressSettings settings)
     {
-        DCAwareRoundRobinPolicy.Builder policyBuilder = DCAwareRoundRobinPolicy.builder();
+        RackAwareRoundRobinPolicy.Builder policyBuilder = RackAwareRoundRobinPolicy.builder();
+
         if (settings.node.datacenter != null)
             policyBuilder.withLocalDc(settings.node.datacenter);
+        if (settings.node.rack != null)
+            policyBuilder.withLocalRack(settings.node.rack);
 
         LoadBalancingPolicy ret = null;
         if (settings.node.datacenter != null)


### PR DESCRIPTION
scylladb/java-driver#227 introduced RackAwareRoundRobinPolicy support for the 3.x branch of scylla's fork of java-driver

this add the new command line to pass down to the stress command which rack should be prefered (same as datacenter):

```
cassandra-stress write no-warmup cl=LOCAL_QUORUM -node rack=rack1 datacenter=dc1 127.0.95.1
```

Ref: https://github.com/scylladb/java-driver/pull/227