### PR TITLE
cassandra-stress: add storage options

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/settings/CliOption.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/CliOption.java
@@ -32,7 +32,7 @@ public enum CliOption
     RATE("Thread count, rate limit or automatic mode (default is auto)", SettingsRate.helpPrinter()),
     MODE("Thrift or CQL with options", SettingsMode.helpPrinter()),
     ERRORS("How to handle errors when encountered during stress", SettingsErrors.helpPrinter()),
-    SCHEMA("Replication settings, compression, compaction, etc.", SettingsSchema.helpPrinter()),
+    SCHEMA("Replication settings, compression, compaction, storage etc.", SettingsSchema.helpPrinter()),
     NODE("Nodes to connect to", SettingsNode.helpPrinter()),
     LOG("Where to log progress to, and the interval at which to do it", SettingsLog.helpPrinter()),
     TRANSPORT("Custom transport factories", SettingsTransport.helpPrinter()),

--- a/tools/stress/src/org/apache/cassandra/stress/settings/OptionStorage.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/OptionStorage.java
@@ -1,0 +1,56 @@
+package org.apache.cassandra.stress.settings;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.base.Function;
+
+/**
+ * For specifying storage options
+ */
+class OptionStorage extends OptionMulti
+{
+    private final OptionSimple type = new OptionSimple("type=", "LOCAL|S3", null, "The storage backend to use", false);
+    private final OptionSimple endpoint = new OptionSimple("endpoint=", ".*", null, "The server address of S3 server", false);
+    private final OptionSimple bucket = new OptionSimple("bucket=", ".*", null, "The bucket hosting the keyspace", false);
+
+    public OptionStorage()
+    {
+        super("storage", "Define the storage backend parameters", true);
+    }
+
+    public String getType()
+    {
+        return type.value();
+    }
+
+    public Map<String, String> getOptions()
+    {
+        Map<String, String> options = extraOptions();
+        if (endpoint.present()) {
+            options.put("endpoint", endpoint.value());
+        }
+        if (bucket.present()) {
+            options.put("bucket", bucket.value());
+        }
+        return options;
+    }
+
+    protected List<? extends Option> options()
+    {
+        return Arrays.asList(type, endpoint, bucket);
+    }
+
+    @Override
+    public boolean happy()
+    {
+        if (!type.present()) {
+            return true;
+        }
+        if (type.value().equals("LOCAL")) {
+            return true;
+        }
+        return endpoint.present() && bucket.present();
+    }
+}

--- a/tools/stress/src/org/apache/cassandra/stress/settings/SettingsSchema.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/SettingsSchema.java
@@ -39,6 +39,9 @@ public class SettingsSchema implements Serializable
     private final String replicationStrategy;
     private final Map<String, String> replicationStrategyOptions;
 
+    private final String storage;
+    private final Map<String, String> storageOptions;
+
     private final String compression;
     private final String compactionStrategy;
     private final Map<String, String> compactionStrategyOptions;
@@ -53,6 +56,8 @@ public class SettingsSchema implements Serializable
 
         replicationStrategy = options.replication.getStrategy();
         replicationStrategyOptions = options.replication.getOptions();
+        storage = options.storage.getType();
+        storageOptions = options.storage.getOptions();
         compression = options.compression.value();
         compactionStrategy = options.compaction.getStrategy();
         compactionStrategyOptions = options.compaction.getOptions();
@@ -123,6 +128,16 @@ public class SettingsSchema implements Serializable
                 b.append(", '").append(entry.getKey()).append("' : '").append(entry.getValue()).append("'");
             }
 
+            b.append("}");
+        }
+
+        if (storage != null) {
+            b.append(" AND storage = {");
+            b.append("'type': '").append(storage).append("'");
+            for (Map.Entry<String, String> entry : storageOptions.entrySet())
+            {
+                b.append(", '").append(entry.getKey()).append("' : '").append(entry.getValue()).append("'");
+            }
             b.append("}");
         }
 
@@ -287,6 +302,7 @@ public class SettingsSchema implements Serializable
     private static final class Options extends GroupedOptions
     {
         final OptionReplication replication = new OptionReplication();
+        final OptionStorage storage = new OptionStorage();
         final OptionCompaction compaction = new OptionCompaction();
         final OptionSimple keyspace = new OptionSimple("keyspace=", ".*", "keyspace1", "The keyspace name to use", false);
         final OptionSimple compression = new OptionSimple("compression=", ".*", null, "Specify the compression to use for sstable, default:no compression", false);
@@ -294,7 +310,7 @@ public class SettingsSchema implements Serializable
         @Override
         public List<? extends Option> options()
         {
-            return Arrays.asList(replication, keyspace, compaction, compression);
+            return Arrays.asList(replication, storage, keyspace, compaction, compression);
         }
     }
 
@@ -304,6 +320,7 @@ public class SettingsSchema implements Serializable
         out.println("  Keyspace: " + keyspace);
         out.println("  Replication Strategy: " + replicationStrategy);
         out.println("  Replication Strategy Options: " + replicationStrategyOptions);
+        out.println("  Storage Options: " + storageOptions);
 
         out.println("  Table Compression: " + compression);
         out.println("  Table Compaction Strategy: " + compactionStrategy);


### PR DESCRIPTION
so we can exercise the object storage backend with cassandra-stress with `-schema 'storage(type=S3,endpoint=127.0.0.1:6001,bucket=testbucket)'`.