### PR TITLE
install-dependencies.sh: do not install weak dependencies

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -22,5 +22,5 @@
 if [ "$ID" = "ubuntu" ] || [ "$ID" = "debian" ]; then
     apt -y install openjdk-8-jdk-headless ant ant-optional python
 elif [ "$ID" = "fedora" ] || [ "$ID" = "centos" ]; then
-    dnf install -y ant java-1.8.0-openjdk-devel python ant-junit fakeroot
+    dnf install -y --setopt=install_weak_deps=False ant java-1.8.0-openjdk-devel python ant-junit fakeroot
 fi


### PR DESCRIPTION
Especially for Java, we really do not need the tens of packages and MBs it adds, just because Java apps can be built and use sound and graphics and whatnot.