### PR TITLE
Fix compilation with Java 11

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -836,10 +836,11 @@
                 <path refid="cassandra.classpath"/>
             </classpath>
         </javac>
-        <echo message="Compiling for current java version ..."/>
+        <echo message="Compiling for Java 11 (using ${env.JAVA11_HOME}/bin/javac) ..."/>
         <javac fork="true"
                debug="true" debuglevel="${debuglevel}" encoding="utf-8"
                destdir="${build.classes.main}/META-INF/versions/11" includeantruntime="false"
+               executable="${env.JAVA11_HOME}/bin/javac"
                memorymaximumsize="512M">
             <src path="${build.src.java11}"/>
             <compilerarg value="--release"/>

--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -77,6 +77,15 @@ if [ -z "$JAVA8_HOME" ]; then
         fi
     done
 fi
+if [ -z "$JAVA11_HOME" ]; then
+    for i in /usr/lib/jvm/java-11
+    do
+        if [ -e "$i" ]; then
+            export JAVA11_HOME="$i"
+            break
+        fi
+    done
+fi
 
 ant jar
 dist/debian/debian_files_gen.py


### PR DESCRIPTION
This is an effort to compile using Java 11 properly - set JAVA11_HOME env. variable and use it in the build XML - just as was done with Java 8.

* needs to be tested via a CI build *