### PR TITLE
dist/redhat: s/jre-8-headless/jre-11-headless/

### DIFF
--- a/dist/redhat/scylla-tools.spec
+++ b/dist/redhat/scylla-tools.spec
@@ -21,7 +21,7 @@ BuildArch:      noarch
 Summary:        Core files for Scylla tools
 Version:        %{version}
 Release:        %{release}%{?dist}
-Requires:       jre-1.8.0-headless
+Requires:       jre-11-headless
 
 %global __brp_python_bytecompile %{nil}
 %global __brp_mangle_shebangs %{nil}

--- a/dist/redhat/scylla-tools.spec
+++ b/dist/redhat/scylla-tools.spec
@@ -18,7 +18,6 @@ Conflicts:      cassandra
 License:        Apache
 URL:            http://www.scylladb.com/
 BuildArch:      noarch
-Requires:       java-headless
 Summary:        Core files for Scylla tools
 Version:        %{version}
 Release:        %{release}%{?dist}


### PR DESCRIPTION
in order to tighten the runtime dependencies on different platforms and different components, also, it is better to use a newer and better supported jre, let's use jre-11 in the rpm packaging as well. we build rpm and deb from the same tarball. and we build for both jre-8 and jre-11, so it should be safe to use jre-11 as the dependency on rpm based distros.