### PR TITLE
NodeProbe: allow addressing table name with colon in it

### DIFF
--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -1460,6 +1460,13 @@ public class NodeProbe implements AutoCloseable
                 // Do we need some other way to address indexes?
                 //String type = cf.contains(".") ? "IndexTable" : "Table";
                 String type = "Table";
+                if (cf.contains(":")) {
+                    // If cf name contains a colon (as happens in Alternator
+                    // GSI) it needs to be quoted otherwise it can't be stored
+                    // in an ObjectName. Only Scylla's fork of the JMX knows
+                    // how to unquote it later, so only quote if necessary.
+                    cf = ObjectName.quote(cf);
+                }
                 oName = new ObjectName(String.format("org.apache.cassandra.metrics:type=%s,keyspace=%s,scope=%s,name=%s", type, ks, cf, metricName));
             }
             else if (!Strings.isNullOrEmpty(ks))


### PR DESCRIPTION
As the ObjectName documentation explains, when an addressing an MBean in JMX, when a value contains a comma, equals, colon or quote - it must be quoted, otherwise the ObjectName cannot be constructed.

CQL or Alternator table names cannot contain any of these characters, but in Alternator the names of secondary indexes *do* contain a colon, so before this patch nodetool cannot address them - it tries to construct an ObjectName with that name, and fails.

Note that "nodetool tablestats" is also broken by this bug, because even if the user doesn't try to specify one specific table, nodetool iterates on all tables and fails when it reaches the view with the colon in its name.

So this patch adds the missing quoting if the table name contains a colon.  We don't quote table names that don't have a colon to preserve backward compatibility with old implmentation of JMX that don't know how to unquote these names. A separate patch to scylla-jmx added support for unquoting - see https://github.com/scylladb/scylla-jmx/pull/227.

After this patch "nodetool tablestats" can work even if there is an Alternator GSI or LSI.