### PR TITLE
cassandra-stress: switch create table to use keyspace.table format

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/settings/SettingsSchema.java
+++ b/tools/stress/src/org/apache/cassandra/stress/settings/SettingsSchema.java
@@ -87,9 +87,7 @@ public class SettingsSchema implements Serializable
         {
             //Keyspace
             client.execute(createKeyspaceStatementCQL3(), org.apache.cassandra.db.ConsistencyLevel.LOCAL_ONE);
-
-            client.execute("USE \""+keyspace+"\"", org.apache.cassandra.db.ConsistencyLevel.LOCAL_ONE);
-
+            
             //Add standard1
             client.execute(createStandard1StatementCQL3(settings), org.apache.cassandra.db.ConsistencyLevel.LOCAL_ONE);
 
@@ -152,7 +150,7 @@ public class SettingsSchema implements Serializable
         StringBuilder b = new StringBuilder();
 
         b.append("CREATE TABLE IF NOT EXISTS ")
-         .append("standard1 (key blob PRIMARY KEY ");
+         .append("\""+keyspace+"\"".standard1 (key blob PRIMARY KEY ");
 
         try
         {


### PR DESCRIPTION
Stop using "Use keyspace" since it can fail when using multiple stress commands in parallel due to a race condition.

fixes: #356