### PR TITLE
cassandra-stress: use RackAwareRoundRobinPolicy if rack is specified

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/util/JavaDriverClient.java
+++ b/tools/stress/src/org/apache/cassandra/stress/util/JavaDriverClient.java
@@ -101,13 +101,16 @@ public class JavaDriverClient
             policyBuilder.withLocalRack(settings.node.rack);
 
         LoadBalancingPolicy ret = null;
-        if (settings.node.datacenter != null)
+        if (settings.node.datacenter != null || settings.node.rack != null)
             ret = policyBuilder.build();
 
         if (settings.node.isWhiteList)
             ret = new WhiteListPolicy(ret == null ? policyBuilder.build() : ret, settings.node.resolveAll(settings.port.nativePort));
 
-        return new TokenAwarePolicy(ret == null ? policyBuilder.build() : ret);
+        if (ret != null) {
+            return ret;
+        }
+        return new TokenAwarePolicy(policyBuilder.build());
     }
 
     public PreparedStatement prepare(String query)


### PR DESCRIPTION
Previously even if `rack` was specified the `TokenAwarePolicy` (with `RackAwareRoundRobinPolicy` as a child policy) was used in cassandra-stress. 

Now if additional arguments are provided it use actual policy specified without wrapping it with `TokenAwarePolicy`.

Fixes: https://github.com/scylladb/java-driver/issues/255