### PR TITLE
Add nodetool interposer script

### DIFF
--- a/bin/nodetool-wrapper
+++ b/bin/nodetool-wrapper
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Copyright (C) 2023-present ScyllaDB
+#
+
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+
+SCRIPT_PATH=$(dirname $(realpath "$0"))
+
+# nodetool is installed to $prefix/share/cassandra/bin, while scylla to $prefix/bin
+SCYLLA_PATH="$SCRIPT_PATH"/../../../bin/scylla
+NODETOOL_PATH=$(realpath "$SCRIPT_PATH"/nodetool-java)
+
+# Fall-back to java nodetool, if the tool-java package is installed, but the
+# scylla-server one isn't.
+if [[ ! -f "$SCYLLA_PATH" ]]
+then
+    exec "$NODETOOL_PATH" "$@"
+fi
+
+SCYLLA_PATH=$(realpath "$SCYLLA_PATH")
+
+# Requesting the help for a command will fail with a distinct error code (100)
+# if the command doesn't exist. Thus we can use the exit code to check whether
+# scylla-nodetool implements a given command or not, and therefore, dispatch
+# the request to the appropriate nodetool variant.
+"$SCYLLA_PATH" nodetool "$1" --help &>/dev/null
+if [[ $? -eq 100 ]]
+then
+    exec "$NODETOOL_PATH" "$@"
+else
+    exec "$SCYLLA_PATH" nodetool "$@"
+fi

--- a/dist/debian/debian/scylla-tools.install
+++ b/dist/debian/debian/scylla-tools.install
@@ -1,5 +1,6 @@
 etc/bash_completion.d/nodetool-completion
 opt/scylladb/share/cassandra/bin/nodetool
+opt/scylladb/share/cassandra/bin/nodetool-java
 opt/scylladb/share/cassandra/bin/sstableloader
 opt/scylladb/share/cassandra/bin/cassandra-stress
 opt/scylladb/share/cassandra/bin/cassandra-stressd
@@ -8,6 +9,7 @@ opt/scylladb/share/cassandra/bin/sstablelevelreset
 opt/scylladb/share/cassandra/bin/sstablemetadata
 opt/scylladb/share/cassandra/bin/sstablerepairedset
 usr/bin/nodetool
+usr/bin/nodetool-java
 usr/bin/sstableloader
 usr/bin/cassandra-stress
 usr/bin/cassandra-stressd

--- a/dist/redhat/scylla-tools.spec
+++ b/dist/redhat/scylla-tools.spec
@@ -42,6 +42,7 @@ rm -rf $RPM_BUILD_ROOT
 %files
 %{_sysconfdir}/bash_completion.d/nodetool-completion
 /opt/scylladb/share/cassandra/bin/nodetool
+/opt/scylladb/share/cassandra/bin/nodetool-java
 /opt/scylladb/share/cassandra/bin/sstableloader
 /opt/scylladb/share/cassandra/bin/cassandra-stress
 /opt/scylladb/share/cassandra/bin/cassandra-stressd
@@ -50,6 +51,7 @@ rm -rf $RPM_BUILD_ROOT
 /opt/scylladb/share/cassandra/bin/sstablemetadata
 /opt/scylladb/share/cassandra/bin/sstablerepairedset
 %{_bindir}/nodetool
+%{_bindir}/nodetool-java
 %{_bindir}/sstableloader
 %{_bindir}/cassandra-stress
 %{_bindir}/cassandra-stressd

--- a/install.sh
+++ b/install.sh
@@ -117,14 +117,19 @@ if $nonroot; then
     sed -i -e "s#/opt/scylladb/#$rprefix/#g" "$rprefix"/share/cassandra/bin/cassandra.in.sh
 fi
 
-# scylla-tools
-install -d -m755 "$retc"/bash_completion.d
-install -m644 dist/common/nodetool-completion "$retc"/bash_completion.d
-for i in bin/{nodetool,sstableloader,scylla-sstableloader} tools/bin/{cassandra-stress,cassandra-stressd,sstabledump,sstablelevelreset,sstablemetadata,sstablerepairedset}; do
-    bn=$(basename $i)
-    install -m755 $i "$rprefix"/share/cassandra/bin
+install_tool_bin () {
+    bin_src=$1
+    bn=$(basename "$bin_src")
+    install -m755 "$bin_src" "$rprefix"/share/cassandra/bin
     if ! $nonroot; then
         echo "$thunk" > "$rusr"/bin/$bn
         chmod 755 "$rusr"/bin/$bn
     fi
+}
+
+# scylla-tools
+install -d -m755 "$retc"/bash_completion.d
+install -m644 dist/common/nodetool-completion "$retc"/bash_completion.d
+for i in bin/{nodetool,sstableloader,scylla-sstableloader} tools/bin/{cassandra-stress,cassandra-stressd,sstabledump,sstablelevelreset,sstablemetadata,sstablerepairedset}; do
+    install_tool_bin "$i"
 done

--- a/install.sh
+++ b/install.sh
@@ -134,6 +134,9 @@ install_tool_bin () {
 # scylla-tools
 install -d -m755 "$retc"/bash_completion.d
 install -m644 dist/common/nodetool-completion "$retc"/bash_completion.d
-for i in bin/{nodetool,sstableloader,scylla-sstableloader} tools/bin/{cassandra-stress,cassandra-stressd,sstabledump,sstablelevelreset,sstablemetadata,sstablerepairedset}; do
+for i in bin/{sstableloader,scylla-sstableloader} tools/bin/{cassandra-stress,cassandra-stressd,sstabledump,sstablelevelreset,sstablemetadata,sstablerepairedset}; do
     install_tool_bin "$i"
 done
+
+install_tool_bin bin/nodetool-wrapper nodetool
+install_tool_bin bin/nodetool nodetool-java

--- a/install.sh
+++ b/install.sh
@@ -119,11 +119,15 @@ fi
 
 install_tool_bin () {
     bin_src=$1
-    bn=$(basename "$bin_src")
-    install -m755 "$bin_src" "$rprefix"/share/cassandra/bin
+    if [ $# -eq 1 ]; then
+        bin_dest=$(basename "$bin_src")
+    else
+        bin_dest=$2
+    fi
+    install -m755 "$bin_src" "$rprefix"/share/cassandra/bin/"$bin_dest"
     if ! $nonroot; then
-        echo "$thunk" > "$rusr"/bin/$bn
-        chmod 755 "$rusr"/bin/$bn
+        echo "$thunk" > "$rusr"/bin/"$bin_dest"
+        chmod 755 "$rusr"/bin/"$bin_dest"
     fi
 }
 


### PR DESCRIPTION
This script is intended as a wrapper for nodetool, first trying to route commands to scylla-nodetool, and if the command is unimplemented, it is routed to the java nodetool. Whether a command is implemented or not is determined by checking the exit-code of scylla-nodetool. An unimplemented command uses a unique exit-code of 100. When this is seen, the command is routed to Java nodetool.
`install.sh` is adjusted to install `nodetool` as `nodetool.java` and `nodetool-wrapper` as `nodetool`. If scylla-nodetool is misbehaving, users can manually fall-back to the legacy nodetool, by invoking `nodetool.java`.

Tests: build both the unified tarball as well as the tools-java one and verified that the script works as intended at the installed location. This will also be checked by Scylla CI.

Refs: https://github.com/scylladb/scylladb/issues/15588