### PR TITLE
Update `Netty` , `Guava` and `Logback` dependencies

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -389,8 +389,8 @@
           <dependency groupId="org.slf4j" artifactId="slf4j-api" version="1.7.25"/>
           <dependency groupId="org.slf4j" artifactId="log4j-over-slf4j" version="1.7.25"/>
           <dependency groupId="org.slf4j" artifactId="jcl-over-slf4j" version="1.7.25" />
-          <dependency groupId="ch.qos.logback" artifactId="logback-core" version="1.2.9"/>
-          <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="1.2.9"/>
+          <dependency groupId="ch.qos.logback" artifactId="logback-core" version="1.2.13"/>
+          <dependency groupId="ch.qos.logback" artifactId="logback-classic" version="1.2.13"/>
           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-core" version="2.15.2"/>
           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-databind" version="2.15.2"/>
           <dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-annotations" version="2.15.2"/>

--- a/build.xml
+++ b/build.xml
@@ -457,8 +457,8 @@
           <dependency groupId="io.airlift" artifactId="airline" version="0.6">
             <exclusion groupId="com.google.code.findbugs" artifactId="jsr305" />
           </dependency>
-          <dependency groupId="io.netty" artifactId="netty-bom" version="4.1.58.Final" type="pom" scope="provided"/>
-          <dependency groupId="io.netty" artifactId="netty-all" version="4.1.58.Final" />
+          <dependency groupId="io.netty" artifactId="netty-bom" version="4.1.100.Final" type="pom" scope="provided"/>
+          <dependency groupId="io.netty" artifactId="netty-all" version="4.1.100.Final" />
           <dependency groupId="com.google.code.findbugs" artifactId="jsr305" version="2.0.2" scope="provided"/>
           <dependency groupId="com.clearspring.analytics" artifactId="stream" version="2.5.2">
             <exclusion groupId="it.unimi.dsi" artifactId="fastutil" />

--- a/build.xml
+++ b/build.xml
@@ -363,7 +363,7 @@
           <dependency groupId="org.xerial.snappy" artifactId="snappy-java" version="1.1.10.4"/>
           <dependency groupId="net.jpountz.lz4" artifactId="lz4" version="1.3.0"/>
           <dependency groupId="com.ning" artifactId="compress-lzf" version="0.8.4"/>
-          <dependency groupId="com.google.guava" artifactId="guava" version="18.0">
+          <dependency groupId="com.google.guava" artifactId="guava" version="32.1.3-jre">
             <exclusion groupId="com.google.code.findbugs" artifactId="jsr305" />
             <exclusion groupId="org.codehaus.mojo" artifactId="animal-sniffer-annotations" />
             <exclusion groupId="com.google.guava" artifactId="listenablefuture" />


### PR DESCRIPTION
This PR updates several dependencies in scylla-tools-java: `Netty` , `Guava` and `Logback`. 
Before the change, security scanners (such as Trivy and the one we have in the docker hub) reported that those dependencies were vulnerable to several "HIGH", "MEDIUM" and "LOW"  severity CVEs. Those issues are fixed in newer versions of those libraries and after this PR the security scanner doesn't report any problems related to the updated dependencies.

Fixes: https://github.com/scylladb/scylla-tools-java/issues/363
Fixes: https://github.com/scylladb/scylla-tools-java/issues/364
Fixes: https://github.com/scylladb/scylla-tools-java/issues/365
