### PR TITLE
Use ReplicaOrdering.NEUTRAL in TokenAwarePolicy to respect RackAwareness

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/util/JavaDriverClient.java
+++ b/tools/stress/src/org/apache/cassandra/stress/util/JavaDriverClient.java
@@ -27,6 +27,7 @@ import com.datastax.driver.core.*;
 import com.datastax.driver.core.policies.RackAwareRoundRobinPolicy;
 import com.datastax.driver.core.policies.LoadBalancingPolicy;
 import com.datastax.driver.core.policies.TokenAwarePolicy;
+import com.datastax.driver.core.policies.TokenAwarePolicy.ReplicaOrdering;
 import com.datastax.driver.core.policies.WhiteListPolicy;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import io.netty.util.internal.logging.Slf4JLoggerFactory;
@@ -107,7 +108,7 @@ public class JavaDriverClient
         if (settings.node.isWhiteList)
             ret = new WhiteListPolicy(ret == null ? policyBuilder.build() : ret, settings.node.resolveAll(settings.port.nativePort));
 
-        return new TokenAwarePolicy(ret == null ? policyBuilder.build() : ret);
+        return new TokenAwarePolicy(ret == null ? policyBuilder.build() : ret, ReplicaOrdering.NEUTRAL);
     }
 
     public PreparedStatement prepare(String query)


### PR DESCRIPTION
If we specify `rack`, we want to have replicas sorted based on which one is local. This happens on the java-driver side if we specify ordering in `TokenAwarePolicy`. Specifically, it has to use `ReplicaOrdering.NEUTRAL`. 

This option was not used before, and that led to broken behavior. Now, Rack Awareness is properly respected.

Fixes: https://github.com/scylladb/java-driver/issues/255 

To test I have used case with 6 nodes, and c-s is using `RackAwareRoundRobinPolicy` that targets only rack `rack1`
and all stress commands are showing the following logs:
```
===== Using optimized driver!!! =====
WARN  13:57:02,324 Some contact points don't match local rack. Local rack = rack1. Non-conforming contact points: /127.0.0.2:9042 (dc=datacenter1, rack=rack2),/127.0.0.3:9042 (dc=datacenter1, rack=rack3),/127.0.0.5:9042 (dc=datacenter1, rack=rack2),/127.0.0.6:9042 (dc=datacenter1, rack=rack3)
Connected to cluster: , max pending requests per connection null, max connections per host 8
Datatacenter: datacenter1; Host: /127.0.0.1; Rack: rack1
Datatacenter: datacenter1; Host: /127.0.0.2; Rack: rack2
Datatacenter: datacenter1; Host: /127.0.0.3; Rack: rack3
Datatacenter: datacenter1; Host: /127.0.0.4; Rack: rack1
Datatacenter: datacenter1; Host: /127.0.0.5; Rack: rack2
Datatacenter: datacenter1; Host: /127.0.0.6; Rack: rack3
```
Before the change for `rf=3` it looked like that (first write operation, after that some reads):
![rack_before](https://github.com/scylladb/scylla-tools-java/assets/52855732/d7dee38c-b709-4c49-a6a8-b4f3324ac4e2)
After the change for the same parameters we see that majority of the requests goes to `127.0.0.1` and `127.0.0.4` (orange and green lines) as it should.
![rack_after](https://github.com/scylladb/scylla-tools-java/assets/52855732/b097d13d-74cc-4b2a-9497-6a07443c6169)

