### PR TITLE
build.xml: install and use java-11 when building

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -174,9 +174,6 @@
     Build instructions for development buils that only support Java 8:
     - requires JDK 8 in JAVA_HOME
     -->
-    <condition property="java.version.8">
-        <equals arg1="${ant.java.version}" arg2="1.8"/>
-    </condition>
     <condition property="java11-jvmargs" value="-Djdk.attach.allowAttachSelf=true --add-exports java.sql/java.sql=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/jdk.internal.module=ALL-UNNAMED --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-exports java.base/sun.nio.ch=ALL-UNNAMED --add-exports java.management.rmi/com.sun.jmx.remote.internal.rmi=ALL-UNNAMED --add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED --add-exports java.rmi/sun.rmi.server=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED">
         <not>
             <equals arg1="${ant.java.version}" arg2="1.8"/>
@@ -792,35 +789,7 @@
     <target name="build" depends="resolver-retrieve-build,build-project" description="Compile Cassandra classes"/>
     <target name="codecoverage" depends="jacoco-run,jacoco-report" description="Create code coverage report"/>
 
-    <target name="_build_java8_only" if="java.version.8">
-        <echo message="Compiling only for Java 8 ..."/>
-        <javac
-               debug="true" debuglevel="${debuglevel}" encoding="utf-8"
-               destdir="${build.classes.thrift}" includeantruntime="false" source="${source.version}" target="${target.version}"
-               memorymaximumsize="512M"
-               >
-            <src path="${interface.thrift.dir}/gen-java"/>
-            <classpath refid="cassandra.classpath"/>
-        </javac>
-        <javac fork="true"
-               debug="true" debuglevel="${debuglevel}" encoding="utf-8"
-               destdir="${build.classes.main}" includeantruntime="false" source="${source.version}" target="${target.version}"
-               memorymaximumsize="512M"
-               >
-            <src path="${build.src.java}"/>
-	    <!-- changed by calle: We don't care about the overhead of
-		 a reentrantlock in atomicbtreepartition, so always
-		 build againt "java 11", aka don't use forbidden api:s
-		 -->
-            <src path="${build.src.java11}"/>
-            <src path="${build.src.gen-java}"/>
-            <compilerarg value="-XDignore.symbol.file"/>
-            <classpath>
-                <path refid="cassandra.classpath"/>
-            </classpath>
-        </javac>
-    </target>
-    <target name="_build_multi_java" unless="java.version.8">
+    <target name="_build_multi_java">
         <!-- Note: we cannot use javac's 'release' option, as that does not allow accessing sun.misc.Unsafe nor
         Nashorn's ClassFilter class as any javac modules option is invalid for relase 8. -->
         <echo message="Compiling for Java 8 (using ${env.JAVA8_HOME}/bin/javac) ..."/>
@@ -856,7 +825,6 @@
             name="build-project">
         <echo message="${ant.project.name}: ${ant.file}"/>
         <!-- Order matters! -->
-        <antcall target="_build_java8_only"/>
         <antcall target="_build_multi_java"/>
         <antcall target="createVersionPropFile"/>
         <copy todir="${build.classes.main}">
@@ -1073,7 +1041,6 @@
 
     <!-- creates release tarballs -->
     <target name="artifacts" depends="jar,gen-doc,build-test,stress-build-test,sources-jar,javadoc-jar"
-            unless="java.version.8"
             description="Create Cassandra release artifacts">
       <mkdir dir="${dist.dir}"/>
       <!-- fix the control linefeed so that builds on windows works on linux -->
@@ -1702,14 +1669,6 @@
     </sequential>
   </macrodef>
 
-  <target name="test" depends="eclipse-warnings,build-test" description="Test Runner">
-    <path id="all-test-classes-path">
-      <fileset dir="${test.unit.src}" includes="**/${test.name}.java" excludes="**/distributed/test/UpgradeTest*.java" />
-    </path>
-    <property name="all-test-classes" refid="all-test-classes-path"/>
-    <testhelper testdelegate="testlist"/>
-  </target>
-
   <target name="generate-test-report" description="Generates JUnit's HTML report from results already in build/output">
       <junitreport todir="${build.test.dir}">
         <fileset dir="${build.test.dir}/output">
@@ -1931,39 +1890,6 @@
   	<delete dir=".externalToolBuilders" />
   	<delete dir="build/eclipse-classes" />
   </target>
-
-  <!-- ECJ 4.6.1 in standalone mode does not work with JPMS, so we skip this target for Java 11 -->
-  <target name="eclipse-warnings" depends="build" description="Run eclipse compiler code analysis" if="java.version.8">
-        <property name="ecj.log.dir" value="${build.dir}/ecj" />
-        <property name="ecj.warnings.file" value="${ecj.log.dir}/eclipse_compiler_checks.txt"/>
-        <mkdir  dir="${ecj.log.dir}" />
-
-        <property name="ecj.properties" value="${basedir}/eclipse_compiler.properties" />
-
-        <echo message="Running Eclipse Code Analysis.  Output logged to ${ecj.warnings.file}" />
-
-	<java
-	    jar="${build.dir.lib}/jars/ecj-${ecj.version}.jar"
-            fork="true"
-	    failonerror="true"
-            maxmemory="512m">
-            <arg value="-source"/>
-	    <arg value="${source.version}" />
-	    <arg value="-target"/>
-	    <arg value="${target.version}" />
-	    <arg value="-d" />
-            <arg value="none" />
-	    <arg value="-proc:none" />
-            <arg value="-log" />
-            <arg value="${ecj.warnings.file}" />
-            <arg value="-properties" />
-            <arg value="${ecj.properties}" />
-            <arg value="-cp" />
-            <arg value="${toString:cassandra.classpath}" />
-            <arg value="${build.src.java}" />
-        </java>
-  </target>
-
 
   <!-- Installs artifacts to local Maven repository -->
   <target name="mvn-install"

--- a/build.xml
+++ b/build.xml
@@ -785,7 +785,7 @@
     <target name="build" depends="resolver-retrieve-build,build-project" description="Compile Cassandra classes"/>
     <target name="codecoverage" depends="jacoco-run,jacoco-report" description="Create code coverage report"/>
 
-    <target name="_build_multi_java">
+    <target name="_build_java">
         <echo message="Compiling for Java (using ${ant.java.version}) ..."/>
         <javac fork="true"
                debug="true" debuglevel="${debuglevel}" encoding="utf-8"
@@ -808,7 +808,7 @@
             name="build-project">
         <echo message="${ant.project.name}: ${ant.file}"/>
         <!-- Order matters! -->
-        <antcall target="_build_multi_java"/>
+        <antcall target="_build_java"/>
         <antcall target="createVersionPropFile"/>
         <copy todir="${build.classes.main}">
             <fileset dir="${build.src.resources}" />

--- a/build.xml
+++ b/build.xml
@@ -838,7 +838,7 @@
                 <path refid="cassandra.classpath"/>
             </classpath>
         </javac>
-        <echo message="Compiling for current java version ..."/>
+        <echo message="Compiling for Java (using ${ant.java.version}) ..."/>
         <javac fork="true"
                debug="true" debuglevel="${debuglevel}" encoding="utf-8"
                destdir="${build.classes.main}/META-INF/versions/11" includeantruntime="false"

--- a/build.xml
+++ b/build.xml
@@ -82,13 +82,8 @@
 
     <property name="doc.dir" value="${basedir}/doc"/>
 
-    <!--
-    We specify '8' instead of '1.8' in source.version to indicate that that this build requires Java 11 _and_ Java 8.
-    Builds that only run against Java 8, _have to_ specify '1.8' for source version. This makes it possible to let
-    CI scripts distinguish between "pure Java 8" releases and "hybrid" releases.
-    -->
-    <property name="source.version" value="8"/>
-    <property name="target.version" value="8"/>
+    <property name="source.version" value="11"/>
+    <property name="target.version" value="11"/>
     <property name="release.version" value="10"/>
 
     <condition property="version" value="${base.version}">
@@ -181,6 +176,8 @@
     </condition>
     <property name="java11-jvmargs" value=""/>
 
+    <property name="jdk11plus-javac-exports" value="--add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED --add-exports java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-exports java.base/sun.nio.ch=ALL-UNNAMED" />
+
     <!--
          Add all the dependencies.
     -->
@@ -228,7 +225,6 @@
             message="Not a source artifact, stopping here." />
         <mkdir dir="${build.classes.main}"/>
         <mkdir dir="${build.classes.thrift}"/>
-        <mkdir dir="${build.classes.main}/META-INF/versions/11"/>
         <mkdir dir="${test.lib}"/>
         <mkdir dir="${test.classes}"/>
         <mkdir dir="${stress.test.classes}"/>
@@ -790,32 +786,19 @@
     <target name="codecoverage" depends="jacoco-run,jacoco-report" description="Create code coverage report"/>
 
     <target name="_build_multi_java">
-        <!-- Note: we cannot use javac's 'release' option, as that does not allow accessing sun.misc.Unsafe nor
-        Nashorn's ClassFilter class as any javac modules option is invalid for relase 8. -->
-        <echo message="Compiling for Java 8 (using ${env.JAVA8_HOME}/bin/javac) ..."/>
-        <javac fork="true"
-               debug="true" debuglevel="${debuglevel}" encoding="utf-8"
-               destdir="${build.classes.main}" includeantruntime="false" source="8" target="8"
-               executable="${env.JAVA8_HOME}/bin/javac"
-               memorymaximumsize="512M">
-            <src path="${build.src.java}"/>
-            <src path="${build.src.java8}"/>
-            <src path="${build.src.gen-java}"/>
-            <src path="${interface.thrift.gen-java}"/>
-            <compilerarg value="-XDignore.symbol.file"/>
-            <classpath>
-                <path refid="cassandra.classpath"/>
-            </classpath>
-        </javac>
         <echo message="Compiling for Java (using ${ant.java.version}) ..."/>
         <javac fork="true"
                debug="true" debuglevel="${debuglevel}" encoding="utf-8"
-               destdir="${build.classes.main}/META-INF/versions/11" includeantruntime="false"
+               destdir="${build.classes.main}" includeantruntime="false"
+               source="${ant.java.version}"
+               target="${ant.java.version}"
                memorymaximumsize="512M">
+            <src path="${build.src.java}"/>
             <src path="${build.src.java11}"/>
-            <compilerarg value="--release"/>
-            <compilerarg value="${release.version}"/>
+            <src path="${build.src.gen-java}"/>
+            <src path="${interface.thrift.gen-java}"/>
             <compilerarg value="-XDignore.symbol.file"/>
+            <compilerarg line="${jdk11plus-javac-exports}"/>
             <classpath>
                 <path refid="cassandra.classpath"/>
             </classpath>

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -20,7 +20,7 @@
 . /etc/os-release
 
 if [ "$ID" = "ubuntu" ] || [ "$ID" = "debian" ]; then
-    apt -y install openjdk-8-jdk-headless ant ant-optional python3
+    apt -y install openjdk-11-jdk-headless ant ant-optional python3
 elif [ "$ID" = "fedora" ] || [ "$ID" = "centos" ]; then
-    dnf install -y --setopt=install_weak_deps=False ant java-1.8.0-openjdk-devel python3 ant-junit fakeroot
+    dnf install -y --setopt=install_weak_deps=False ant java-11-openjdk-devel python3 ant-junit fakeroot
 fi

--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -16,8 +16,8 @@ function select_java_home() {
 
     for expected_java_version in $expected_java_versions; do
         for java_home in /usr/lib/jvm/*; do
-            java=$java_home/bin/java
-            javaver=$($java -XshowSettings:properties -version 2>&1 | awk -F' = ' '/java.specification.version/ {print $NF}')
+            javac=$java_home/bin/javac
+            javaver=$($javac -version 2>&1 | awk -F'[ .]' '/javac/ {print $2}')
             if [ "$javaver" = $expected_java_version ]; then
                 echo $java_home
                 return
@@ -86,6 +86,14 @@ printf "version=%s" $VERSION > build.properties
 # dbuild sets it), let's try some common possibilities
 if [ -z "$JAVA8_HOME" ]; then
     export JAVA8_HOME=$(select_java_home 1.8)
+fi
+
+if [ -z "$JAVA_HOME" ]; then
+    export JAVA_HOME=$(select_java_home 11)
+    if [ -z "$JAVA_HOME" ]; then
+        echo "unable to find jdk-11" 2>&1
+        exit 1
+    fi
 fi
 
 ant jar

--- a/reloc/build_reloc.sh
+++ b/reloc/build_reloc.sh
@@ -82,12 +82,8 @@ fi
 
 printf "version=%s" $VERSION > build.properties
 
-# Our ant build.xml requires JAVA8_HOME to be set. In case it wasn't (e.g.,
+# Our ant build.xml requires JAVA_HOME to be set. In case it wasn't (e.g.,
 # dbuild sets it), let's try some common possibilities
-if [ -z "$JAVA8_HOME" ]; then
-    export JAVA8_HOME=$(select_java_home 1.8)
-fi
-
 if [ -z "$JAVA_HOME" ]; then
     export JAVA_HOME=$(select_java_home 11)
     if [ -z "$JAVA_HOME" ]; then


### PR DESCRIPTION
before this change, we rely on JAVA_HOME to build for java11 target.
but user might set JAVA_HOME to a java-8, in this case the `javac`
from openjdk-8 would fail to compile, because it does not understand
the `--release` option:
```
    [javac] Compiling 1 source file to /home/piotrs/src/scylla2/tools/java/build/classes/main/META-INF/versions/11
    [javac] javac: invalid flag: --release
    [javac] Usage: javac <options> <source files>
    [javac] use -help for a list of possible options
```

in this change, we use the JAVA11_HOME environmental variable exposed by
`build_reloc.sh`, so that ant is able to build with the proper java even
if user sets JAVA_HOME to java-8.