### PR TITLE
bin/nodetool-wrapper: pass all args to nodetool for testings its ability

### DIFF
--- a/bin/nodetool-wrapper
+++ b/bin/nodetool-wrapper
@@ -26,7 +26,19 @@ SCYLLA_PATH=$(realpath "$SCYLLA_PATH")
 # if the command doesn't exist. Thus we can use the exit code to check whether
 # scylla-nodetool implements a given command or not, and therefore, dispatch
 # the request to the appropriate nodetool variant.
-"$SCYLLA_PATH" nodetool "$1" --help &>/dev/null
+
+help_opt="--help"
+for opt in "$@"; do
+    # if "--help" is already in the command line, no need to added it for
+    # checking scylla-nodetool implements the given command.
+    if [ "$opt" = "$help_opt" ]; then
+        help_opt=""
+        break
+    fi
+done
+
+"$SCYLLA_PATH" nodetool "$@" $help_opt &>/dev/null
+
 if [[ $? -eq 100 ]]
 then
     exec "$NODETOOL_PATH" "$@"


### PR DESCRIPTION
as the first argument is not necessary the subcommand. in some cases, the caller could pass "-p <port>" or "-h <host>" as the first option, or whatever it prefer. so feed "scylla nodetool" with all command line options to test is ability, use it only if it is able to handle all of them.