### PR TITLE
build.xml: update scylla-driver-core to 3.11.5.2

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -34,7 +34,7 @@
 
     <!-- default version and SCM information -->
     <property name="base.version" value="3.11.13"/>
-    <property name="base.javaDriverVersion" value="3.11.5.1"/>
+    <property name="base.javaDriverVersion" value="3.11.5.2"/>
     <property name="scm.connection" value="scm:https://gitbox.apache.org/repos/asf/cassandra.git"/>
     <property name="scm.developerConnection" value="scm:https://gitbox.apache.org/repos/asf/cassandra.git"/>
     <property name="scm.url" value="https://gitbox.apache.org/repos/asf?p=cassandra.git;a=tree"/>


### PR DESCRIPTION
ScyllaDB Java Driver 3.11.5.2 adds tablet awareness to the driver. Update the version of the driver in scylla-tools-java so that cassandra-stress can take advantage of this new functionality.

Before releasing Java Driver 3.11.5.2 we ran several tests with cassandra-stress to make sure that it's stable (under tablet migration, topology changes) and that there is no performance regression. (More details here: https://github.com/scylladb/java-driver/pull/237#issuecomment-1961751527)