### PR TITLE
nodetool: fix a typo in error message

### DIFF
--- a/src/java/org/apache/cassandra/tools/nodetool/TopPartitions.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/TopPartitions.java
@@ -65,7 +65,7 @@ public class TopPartitions extends NodeToolCmd
     @Override
     public void execute(NodeProbe probe)
     {
-        checkArgument(topCount < size, "TopK count (-k) option must be smaller then the summary capacity (-s)");
+        checkArgument(topCount < size, "TopK count (-k) option must be smaller than the summary capacity (-s)");
         PrintStream out = probe.output().out;
         // generate the list of samplers
         List<Sampler> targets = Lists.newArrayList();


### PR DESCRIPTION
s/smaller then/smaller than/