### PR TITLE
install-dependencies.sh: s/python/python3/

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -20,7 +20,7 @@
 . /etc/os-release
 
 if [ "$ID" = "ubuntu" ] || [ "$ID" = "debian" ]; then
-    apt -y install openjdk-8-jdk-headless ant ant-optional python
+    apt -y install openjdk-8-jdk-headless ant ant-optional python3
 elif [ "$ID" = "fedora" ] || [ "$ID" = "centos" ]; then
-    dnf install -y --setopt=install_weak_deps=False ant java-1.8.0-openjdk-devel python ant-junit fakeroot
+    dnf install -y --setopt=install_weak_deps=False ant java-1.8.0-openjdk-devel python3 ant-junit fakeroot
 fi


### PR DESCRIPTION
python is EOL. and the scripts in this repo actually are using python3 instead python:

```console
$ find . -name '*.py' -exec grep '#!' {} \;
```
also, "python" as a package name is not available in debian and and some of its derivative distros, see
https://packages.debian.org/search?keywords=python&searchon=names&suite=stable&section=all and
https://packages.ubuntu.com/search?suite=jammy&section=all&arch=any&keywords=python3&searchon=names

but python3, or better off python3-minimal is.
see
https://packages.debian.org/search?keywords=python3-minimal&searchon=names&suite=stable&section=all and
https://packages.ubuntu.com/search?suite=jammy&section=all&arch=any&keywords=python3-minimal&searchon=names

ubuntu/jammy is picked, because it is currently the ubuntu-latest os provided by github workflow runners.

so, in this change, let's replace "python" with "python3", so that we can run `install-dependencies.sh` without error like:

```
Package python is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  2to3 python2-minimal python2 dh-python python-is-python3

E: Package 'python' has no installation candidate
```