### PR TITLE
build: run antlr in a separate process

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -272,6 +272,7 @@
       <echo>Building Grammar ${build.src.antlr}/Cql.g  ...</echo>
       <java classname="org.antlr.Tool"
             classpathref="cql3-grammar.classpath"
+            fork="true"
             failonerror="true">
          <arg value="-Xconversiontimeout" />
          <arg value="10000" />


### PR DESCRIPTION
Running antlr in the same JVM as ant itself fails on Fedora 40, reason unknown. The JVM quits with exit code 0 after performing the antlr task and doesn't go on to the compilation tasks. Perhaps Fedora 40's antlr has a System.exit(0) somewhere.

Workaround by forking to a new process.