### PR TITLE
nodetool status, ring: fix effectiveOwnership() error reporting

### DIFF
--- a/src/java/org/apache/cassandra/tools/nodetool/Ring.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Ring.java
@@ -75,24 +75,22 @@ public class Ring extends NodeToolCmd
         String format = format(formatPlaceholder, maxAddressLength);
 
         StringBuilder errors = new StringBuilder();
-        boolean showEffectiveOwnership = true;
+        boolean showEffectiveOwnership = false;
         // Calculate per-token ownership of the ring
         Map<InetAddress, Float> ownerships;
-        try
-        {
-            ownerships = probe.effectiveOwnership(keyspace);
-        }
-        catch (IllegalStateException ex)
-        {
+        if (keyspace != null && !keyspace.equals(""))
+            try
+            {
+                ownerships = probe.effectiveOwnership(keyspace);
+                showEffectiveOwnership = true;
+            }
+            catch (IllegalStateException ex)
+            {
+                out.printf("%nError: %s%n", ex.getMessage());
+                return;
+            }
+        else
             ownerships = probe.getOwnership();
-            errors.append("Note: ").append(ex.getMessage()).append("%n");
-            showEffectiveOwnership = false;
-        }
-        catch (IllegalArgumentException ex)
-        {
-            out.printf("%nError: %s%n", ex.getMessage());
-            return;
-        }
 
 
         out.println();

--- a/src/java/org/apache/cassandra/tools/nodetool/Status.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/Status.java
@@ -72,22 +72,19 @@ public class Status extends NodeToolCmd
 
         Map<InetAddress, Float> ownerships = null;
         boolean hasEffectiveOwns = false;
-        try
-        {
-            ownerships = probe.effectiveOwnership(keyspace);
-            hasEffectiveOwns = true;
-        }
-        catch (IllegalStateException e)
-        {
+        if (keyspace != null && !keyspace.equals(""))
+            try
+            {
+                ownerships = probe.effectiveOwnership(keyspace);
+                hasEffectiveOwns = true;
+            }
+            catch (IllegalStateException ex)
+            {
+                out.printf("%nError: %s%n", ex.getMessage());
+                System.exit(1);
+            }
+        else
             ownerships = probe.getOwnership();
-            errors.append("Note: ").append(e.getMessage()).append("%n");
-        }
-        catch (IllegalArgumentException ex)
-        {
-            out.printf("%nError: %s%n", ex.getMessage());
-            System.exit(1);
-        }
-
         SortedMap<String, SetHostStat> dcs = NodeTool.getOwnershipByDc(probe, resolveIp, tokensToEndpoints, ownerships);
 
         // More tokens than nodes (aka vnodes)?


### PR DESCRIPTION
~~~
nodetool status, ring: fix effectiveOwnership() error reporting

The IllegalArgumentException catch stanza around the effectiveOwnership()
method call goes back to "scylla-tools-java" commit d002c7edc58b ("Don't
output nonsense ownership without a keyspace", 2014-09-13). It was
originally meant to handle the case when the user specified a keyspace,
but the keyspace couldn't be found. In that case, nodetool was expected to
fail at once.

Today, the IllegalArgumentException catch stanza is dead code, as the
StorageService managed bean (having been rebased to scylladb) never throws
an IllegalArgumentException; it only propagates scylladb-originated errors
as IllegalStateException. Consequently, when the user asks for a
nonexistent keyspace, we pretend the user didn't ask for a keyspace at
all, and continue with getOwnership().

If the user asks for a keyspace, make any IllegalStateException a hard
failure. Reach the getOwnership() call only if the user does not ask for a
keyspace.

In addition to "nodetool status", "nodetool ring" consumes the
effectiveOwnership() storage service. Reflect the same change to "nodetool
ring".

Cc: Amnon Heiman <amnon@scylladb.com>
Signed-off-by: Laszlo Ersek <laszlo.ersek@scylladb.com>
~~~