### PR TITLE
install.sh: apply correct security context on offline installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -76,6 +76,10 @@ if [ -z "$prefix" ]; then
     fi
 fi
 
+install() {
+    command install -Z "$@"
+}
+
 scylla_version=$(cat SCYLLA-VERSION-FILE)
 scylla_release=$(cat SCYLLA-RELEASE-FILE)
 


### PR DESCRIPTION
Same as scylla core repo, we need to run "install -Z" to install files with correct file security context, otherwise we may see SELinux permission error.

Related scylladb/scylladb#8589