### PR TITLE
dist: support smooth upgrade from enterprise to source availalbe

### DIFF
--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -11,7 +11,8 @@ Architecture: all
 Depends: %{product}-conf, %{product}-tools-core, ${misc:Depends}
 Recommends: ntp | time-daemon
 Conflicts: cassandra
-Breaks: %{product}-server (<< 5.5)
+Replaces: scylla-enterprise-tools (<< 2025.1.0~)
+Breaks: %{product}-server (<< 5.5), scylla-enterprise-server (<< 2024.2.0~), scylla-enterprise-tools (<< 2025.1.0~)
 Description: Scylla database tools
  Scylla is a highly scalable, eventually consistent, distributed,
  partitioned row DB.
@@ -19,5 +20,24 @@ Description: Scylla database tools
 Package: %{product}-tools-core
 Architecture: all
 Depends: openjdk-8-jre-headless | openjdk-8-jre | oracle-java8-set-default | adoptopenjdk-8-hotspot-jre | openjdk-11-jre-headless | openjdk-11-jre | oracle-java11-set-default, procps
+Replaces: scylla-enterprise-tools-core (<< 2025.1.0~)
+Breaks: scylla-enterprise-tools-core (<< 2025.1.0~)
 Description: Scylla database tools core files
  Core files for scylla database tools
+
+
+Package: scylla-enterprise-tools
+Depends: %{product}-tools (= ${binary:Version})
+Architecture: all
+Priority: optional
+Section: oldlibs
+Description: transitional package
+ This is a transitional package. It can safely be removed.
+
+Package: scylla-enterprise-tools-core
+Depends: %{product}-tools-core (= ${binary:Version})
+Architecture: all
+Priority: optional
+Section: oldlibs
+Description: transitional package
+ This is a transitional package. It can safely be removed.

--- a/dist/redhat/scylla-tools.spec
+++ b/dist/redhat/scylla-tools.spec
@@ -11,6 +11,8 @@ BuildArch:      noarch
 Requires:       %{product}-conf %{product}-tools-core
 AutoReqProv:    no
 Conflicts:      cassandra
+Provides:       scylla-enterprise-tools = %{version}-%{release}
+Obsoletes:      scylla-enterprise-tools < 2025.1.0
 
 %description
 
@@ -22,6 +24,9 @@ Summary:        Core files for Scylla tools
 Version:        %{version}
 Release:        %{release}%{?dist}
 Requires:       jre-11-headless
+Provides:       scylla-enterprise-tools-core = %{version}-%{release}
+Obsoletes:      scylla-enterprise-tools-core < 2025.1.0
+
 
 %global __brp_python_bytecompile %{nil}
 %global __brp_mangle_shebangs %{nil}


### PR DESCRIPTION
This is part of https://github.com/scylladb/scylladb/pull/22821, need to fix https://github.com/scylladb/scylladb/issues/22820

----

When upgrading for example from `2024.1` to `2025.1` the package name is not identical casuing the upgrade command to fail.

This makes packages upgradable from enterprise.

Related scylladb/scylladb#22820